### PR TITLE
Add status badges to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # hmpps-architecture-as-code
 
+![Publish](https://github.com/ministryofjustice/hmpps-architecture-as-code/workflows/Publish/badge.svg)
+![Build and validate](https://github.com/ministryofjustice/hmpps-architecture-as-code/workflows/Build%20and%20validate/badge.svg)
+
 Modelling architecture in HM Prisons and Probations Service (HMPPS) with the [C4 model][c4] and [Structurizr][structurizr].
 
 ## Workspaces


### PR DESCRIPTION
## What does this pull request do?

Adds [GitHub action](https://github.com/ministryofjustice/hmpps-architecture-as-code/actions) badges to the readme.

![image](https://user-images.githubusercontent.com/1526295/85630755-27486300-b66c-11ea-8b8d-262e6ee77c87.png)

## What is the intent behind these changes?

I think badges make it easier to find out that the project is built and published.

Plus, they look neat :neckbeard: 