### PR TITLE
Adds views for Prisoner Content Hub

### DIFF
--- a/src/main/kotlin/prison/views.kt
+++ b/src/main/kotlin/prison/views.kt
@@ -17,10 +17,22 @@ fun prisonViews(model: Model, views: ViewSet) {
   }
 
   val prisonerContentHub = model.getSoftwareSystemWithName("Prisoner Content Hub")!!
+  views.createSystemContextView(prisonerContentHub, "prisonerContentHubSystemContext", "The system context diagram for the Prisoner Content Hub"
+  ).apply {
+    addDefaultElements()
+    enableAutomaticLayout()
+  }
+
   views.createContainerView(prisonerContentHub, "prisonerContentHubContainer", null).apply {
     addDefaultElements()
     enableAutomaticLayout()
   }
+
+  views.createDeploymentView(prisonerContentHub, "prisonerContentHubContainerProductionDeployment", "The Production deployment scenario for the Prisoner Content Hub").apply {
+    addDefaultElements()
+    enableAutomaticLayout()
+  }
+
 
   val pathfinder = model.getSoftwareSystemWithName("Pathfinder")!!
   views.createContainerView(pathfinder, "pathfinderContainer",


### PR DESCRIPTION
## What does this pull request do?

This PR adds a basic deployment diagram:
<img width="1003" alt="Screenshot 2020-07-02 08 51 50" src="https://user-images.githubusercontent.com/464482/86331818-81838e00-bc41-11ea-9906-92f05e46d096.png">

> I'm not sure why this doesn't have labels on the deployment boxes while other examples elsewhere do, ideas welcome!

and a system context diagram
<img width="1121" alt="Screenshot 2020-07-02 at 08 54 16" src="https://user-images.githubusercontent.com/464482/86331916-a5df6a80-bc41-11ea-98fd-4653b6882371.png">

## What is the intent behind these changes?

To add a couple more examples of how we render diagrams from the models we've created.
