### PR TITLE
Only use custom style for software systems

### DIFF
--- a/src/main/kotlin/shared/styles.kt
+++ b/src/main/kotlin/shared/styles.kt
@@ -4,7 +4,7 @@ import com.structurizr.view.Shape
 import com.structurizr.view.Styles
 
 fun styles(styles: Styles) {
-  styles.addElementStyle("Element").color("#ffffff").background("#006699")
+  styles.addElementStyle("Software System").color("#ffffff").background("#006699")
 
   styles.addElementStyle("database").shape(Shape.Cylinder)
   styles.addElementStyle("Person").shape(Shape.Person).background("#0099cc")


### PR DESCRIPTION

## What does this pull request do?

- Removes custom styling from `Element`(which includes Software Systems _and_ Containers.
- Adds that custom styling to `Software System`s

## What is the intent behind these changes?

The style applied to Elements causes Deployment Diagrams to be generated with white text on a white background. This change switched Element back to default grey rendering, and only uses the custom style for Software Systems. This also eases differentiation of the two types of object:
<img width="804" alt="Screenshot 2020-07-02 at 09 22 38" src="https://user-images.githubusercontent.com/464482/86334817-9a8e3e00-bc45-11ea-9cc1-ffd5dd3fced5.png">

