### PR TITLE
Add Elasticsearch/Kibana to AWS Elasticsearch Service

### DIFF
--- a/src/main/kotlin/prison/prisonerContentHub.kt
+++ b/src/main/kotlin/prison/prisonerContentHub.kt
@@ -19,6 +19,7 @@ class PrisonerContentHub(model: Model) {
     val cloudPlatform = model.getDeploymentNodeWithName("Cloud Platform")
     val rds = cloudPlatform.getDeploymentNodeWithName("RDS")
     val s3 = cloudPlatform.getDeploymentNodeWithName("S3")
+    val elasticSearch = cloudPlatform.getDeploymentNodeWithName("ElasticSearch")
     val kubernetes = cloudPlatform.getDeploymentNodeWithName("Kubernetes")
 
     system = model.addSoftwareSystem(
@@ -30,7 +31,7 @@ class PrisonerContentHub(model: Model) {
     val elasticSearchStore = system.addContainer("ElasticSearch store", "Data store for feedback collection, and indexing for Drupal CMS content", "ElasticSearch").apply {
       Tags.DATABASE.addTo(this)
       Tags.SOFTWARE_AS_A_SERVICE.addTo(this)
-      cloudPlatform.add(this)
+      elasticSearch.add(this)
     }
 
     val drupalDatabase = system.addContainer("Drupal database", null, "MariaDB").apply {
@@ -63,7 +64,7 @@ class PrisonerContentHub(model: Model) {
     val kibanaDashboard = system.addContainer("Kibana dashboard", "Feedback reports and analytics dashboard", "Kibana").apply {
       //setUrl("TODO")
       uses(elasticSearchStore, "HTTPS Rest API")
-      cloudPlatform.add(this)
+      elasticSearch.add(this)
     }
 
     /**


### PR DESCRIPTION
## What does this pull request do?

Moves the ElasticSearch & Kibana dashboard into the AWS ElasticSearch Service deployment box, because AWS provides these as a managed service.
<img width="189" alt="Screenshot 2020-07-02 at 10 23 25" src="https://user-images.githubusercontent.com/464482/86341337-12606680-bc4e-11ea-90fb-10085bba04d5.png">

## What is the intent behind these changes?

Making the Prisoner Content Hub deployment diagram more accurate
