### PR TITLE
add pathfinder deployment diagram

### DIFF
--- a/src/main/kotlin/prison/views.kt
+++ b/src/main/kotlin/prison/views.kt
@@ -64,4 +64,9 @@ fun prisonViews(model: Model, views: ViewSet) {
     isEnterpriseBoundaryVisible = false
   }
 
+  views.createDeploymentView(pathfinder, "PathfinderProductionDeployment", "The Production deployment scenario for the Pathfinder service").apply {
+    addDefaultElements()
+    enableAutomaticLayout()
+  }
+
 }


### PR DESCRIPTION
## What does this pull request do?

Add a deployment diagram for the pathfinder service

![Screenshot 2020-07-02 at 11 21 36](https://user-images.githubusercontent.com/1029557/86347638-7b4bdc80-bc56-11ea-9f4d-742a82db2b34.png)

## What is the intent behind these changes?

Enhance the Pathfinder set of diagrams