### PR TITLE
Create supplementary files into "exports" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,5 @@
 # Ignore Gradle build output directory
 build
 
-# files saved by Structurizr API, CLI or scripts
-structurizr-*.json
-structurizr-*.puml
-structurizr-*.png
-
 # external dependencies
 ext/

--- a/exports/.gitignore
+++ b/exports/.gitignore
@@ -1,0 +1,4 @@
+# files saved by Structurizr API, CLI or scripts
+structurizr-*.json
+structurizr-*.puml
+structurizr-*.png

--- a/script/generate_images.sh
+++ b/script/generate_images.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 root_dir="$(git rev-parse --show-toplevel)"
 ext_dir="$root_dir/ext"
+exports_dir="$root_dir/exports"
 cli_version="1.2.0"
 cli_zip="$ext_dir/cli.zip"
 
@@ -19,9 +20,11 @@ echo "🚧 Generating Structurizr workspaces..."
 
 echo
 echo "🌿 Generating PlantUML..."
-find "$root_dir" -name 'structurizr-*-local.json' \
-  -exec "$ext_dir/structurizr.sh" export -workspace {} -f plantuml \;
+(cd "$exports_dir"; \
+ find "$root_dir" -name 'structurizr-*-local.json' \
+   -exec "$ext_dir/structurizr.sh" export -workspace {} -f plantuml \;)
 
 echo
 echo "🖼 Generating images..."
-plantuml -SmaxMessageSize=100 -tpng structurizr-*.puml
+(cd "$exports_dir"; \
+ plantuml -SmaxMessageSize=100 -tpng structurizr-*.puml)

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -8,6 +8,8 @@ import uk.gov.justice.hmpps.architecture.prison.*
 import uk.gov.justice.hmpps.architecture.probation.*
 
 object App {
+  val EXPORT_LOCATION = File("./exports")
+
   @JvmStatic
   fun main(args: Array<String>) {
     val workspace = chooseWorkspace(args)
@@ -21,13 +23,14 @@ object App {
   fun pushToRemote(workspace: Workspace) {
     val client = StructurizrClient(System.getenv("STRUCTURIZR_API_KEY"), System.getenv("STRUCTURIZR_API_SECRET"))
     val workspaceId = System.getenv("STRUCTURIZR_WORKSPACE_ID")?.toLongOrNull() ?: workspace.id
+    client.workspaceArchiveLocation = EXPORT_LOCATION
 
     workspace.version = System.getenv("BUILD_VERSION")
     client.putWorkspace(workspaceId, workspace)
   }
 
   fun writeToFile(workspace: Workspace) {
-    val targetFile = File("structurizr-${workspace.id}-local.json")
+    val targetFile = File(EXPORT_LOCATION, "structurizr-${workspace.id}-local.json")
     WorkspaceUtils.saveWorkspaceToJson(workspace, targetFile)
     println("Wrote workspace to '$targetFile'")
   }


### PR DESCRIPTION
## What does this pull request do?

Create all *.json, *.puml, *.png files in the `exports/` directory.

## What is the intent behind these changes?

To reduce noise in the root of the project, as a follow-up to #21.