### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Ministry of Justice
+Crown Copyright (c) 2020 Ministry of Justice
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What does this pull request do?

This PR adds the MIT License, allowing us to resolve #5.

## What is the intent behind these changes?

Contributing back to the development community with permissive open-source licenses is a Good Thing™️. 

[Several](https://github.com/ministryofjustice/prisonstaffhub) [other](https://github.com/ministryofjustice/manage-hmpps-auth-accounts) [MoJ](https://github.com/ministryofjustice/cloud-platform-infrastructure) [projects](https://github.com/ministryofjustice/pttp-infrastructure) use the MIT License, and it was recommended over the Open Government License by GDS (albeit a long time ago). Their rationale is explained [here](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/#comment-2388):

> MIT felt more appropriate as a license for code as it's designed for that purpose. It's also more widely recognised in the software world and so makes it easier for other developers to make decisions about whether or not to use our code.
