### PR TITLE
Add editorconfig for #11

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig https://EditorConfig.org
+
+# this is the top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+


### PR DESCRIPTION
## What does this pull request do?

Adds [EditorConfig](https://editorconfig.org) for this repo. _If_ you have the EditorConfig plugin for your editor, it'll automatically format code this way. As a starting point, it sets

- 2-space tabs
- UNIX newlines
- Newline at the end of the file

## What is the intent behind these changes?

To increase consistency in contributions, working towards #11.
