### PR TITLE
Content hub improvements

### DIFF
--- a/src/main/kotlin/prison/hmppsAuth.kt
+++ b/src/main/kotlin/prison/hmppsAuth.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.hmpps.architecture.prison
 
+import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 
@@ -7,6 +8,8 @@ class HmmpsAuth(model: Model) {
   val system: SoftwareSystem
 
   init {
-    system = model.addSoftwareSystem("HMPPS Auth", "Allows users to login into digital services")
+    system = model.addSoftwareSystem("HMPPS Auth", "Allows users to login into digital services").apply {
+      setLocation(Location.Internal)
+    }
   }
 }

--- a/src/main/kotlin/prison/nomis.kt
+++ b/src/main/kotlin/prison/nomis.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.hmpps.architecture.prison
 
+import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.Container
 import com.structurizr.model.SoftwareSystem
@@ -21,7 +22,9 @@ class NOMIS(model: Model) {
     system = model.addSoftwareSystem("NOMIS", """
     National Offender Management Information System,
     the case management system for offender data in use in custody - both public and private prisons
-    """.trimIndent())
+    """.trimIndent()).apply {
+      setLocation(Location.Internal)
+    }
 
     db = system.addContainer("NOMIS database", null, "Oracle").apply {
       Tags.DATABASE.addTo(this)

--- a/src/main/kotlin/prison/prisonerContentHub.kt
+++ b/src/main/kotlin/prison/prisonerContentHub.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.hmpps.architecture.prison
 
 import com.structurizr.model.Container
+import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 
@@ -73,22 +74,27 @@ class PrisonerContentHub(model: Model) {
     
     model.addPerson("Feedback Reporter", "HMPPS Staff collating feedback for protection, product development and analytics").apply {
       uses(kibanaDashboard, "Extracts CSV files of prisoner feedback, views individual feedback responses, and analyses sentiment and statistics of feedback")
+      setLocation(Location.Internal)
     };
 
     model.addPerson("Prisoner", "A prisoner over 18 years old, held in the public prison estate").apply {
       uses(contentHubFrontend, "Views videos, audio programmes, site updates, and rehabilitative material")
+      setLocation(Location.External)
     };
 
     model.addPerson("Young Offender", "A person under 18, held in a Young Offender Institute").apply {
       uses(contentHubFrontend, "Views videos, audio programmes, site updates, and rehabilitative material")
+      setLocation(Location.External)
     };
 
     model.addPerson("Content editor", "HMPPS Digital staff curating content for the entire prison estate and supporting individual prisons").apply {
       uses(drupal, "Authors and curates content for the prison estate")
+      setLocation(Location.Internal)
     };
 
     model.addPerson("Prison Content editor", "A content author on-site in a prison, authoring content for their prison").apply {
       uses(drupal, "Authors and curates content for their prison")
+      setLocation(Location.External)
     };
   }
 }

--- a/src/main/kotlin/prison/prisonerContentHub.kt
+++ b/src/main/kotlin/prison/prisonerContentHub.kt
@@ -96,7 +96,7 @@ class PrisonerContentHub(model: Model) {
 
     model.addPerson("Prison Content editor", "A content author on-site in a prison, authoring content for their prison").apply {
       uses(drupal, "Authors and curates content for their prison")
-      setLocation(Location.External)
+      setLocation(Location.Internal)
     };
   }
 }

--- a/src/main/kotlin/prison/prisonerContentHub.kt
+++ b/src/main/kotlin/prison/prisonerContentHub.kt
@@ -34,13 +34,13 @@ class PrisonerContentHub(model: Model) {
       elasticSearch.add(this)
     }
 
-    val drupalDatabase = system.addContainer("Drupal database", null, "MariaDB").apply {
+    val drupalDatabase = system.addContainer("Drupal database", "Prisoner Content Hub CMS data and Drupal metadata", "MariaDB").apply {
       Tags.DATABASE.addTo(this)
       Tags.SOFTWARE_AS_A_SERVICE.addTo(this)
       rds.add(this)
     }
 
-    val s3ContentStore = system.addContainer("Content Store", "Stores audio, video, PDF and image content", "S3").apply {
+    val s3ContentStore = system.addContainer("Content Store", "Audio, video, PDF and image content for the Prisoner Content Hub", "S3").apply {
       Tags.DATABASE.addTo(this)
       Tags.SOFTWARE_AS_A_SERVICE.addTo(this)
       s3.add(this)

--- a/src/main/kotlin/prison/prisonerContentHub.kt
+++ b/src/main/kotlin/prison/prisonerContentHub.kt
@@ -27,7 +27,9 @@ class PrisonerContentHub(model: Model) {
       "Prisoner Content Hub", 
       """
       The Prisoner Content Hub is a platform for prisoners to access data, content and services supporting individual progression and freeing up staff time.
-      """.trimIndent())
+      """.trimIndent()).apply {
+      setLocation(Location.Internal)
+    }
 
     val elasticSearchStore = system.addContainer("ElasticSearch store", "Data store for feedback collection, and indexing for Drupal CMS content", "ElasticSearch").apply {
       Tags.DATABASE.addTo(this)

--- a/src/main/kotlin/prison/views.kt
+++ b/src/main/kotlin/prison/views.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.hmpps.architecture.prison
 
 import com.structurizr.model.Model
+import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
 
 fun prisonViews(model: Model, views: ViewSet) {
@@ -20,17 +21,17 @@ fun prisonViews(model: Model, views: ViewSet) {
   views.createSystemContextView(prisonerContentHub, "prisonerContentHubSystemContext", "The system context diagram for the Prisoner Content Hub"
   ).apply {
     addDefaultElements()
-    enableAutomaticLayout()
+    enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
   }
 
   views.createContainerView(prisonerContentHub, "prisonerContentHubContainer", null).apply {
     addDefaultElements()
-    enableAutomaticLayout()
+    enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
   }
 
   views.createDeploymentView(prisonerContentHub, "prisonerContentHubContainerProductionDeployment", "The Production deployment scenario for the Prisoner Content Hub").apply {
     addDefaultElements()
-    enableAutomaticLayout()
+    enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
   }
 
 

--- a/src/main/kotlin/prison/workspace.kt
+++ b/src/main/kotlin/prison/workspace.kt
@@ -9,8 +9,8 @@ fun prisonWorkspace(): Workspace {
   val hmpps_prisons = Enterprise("HMPPS Prisons")
   val workspace = Workspace("Prison systems", "Systems related to the confinement of offenders").apply {
     model.setEnterprise(hmpps_prisons)
+    setId(55246)
   }
-  workspace.id = 55246
 
   cloudPlatform(workspace.model)
   prisonModel(workspace.model)

--- a/src/main/kotlin/prison/workspace.kt
+++ b/src/main/kotlin/prison/workspace.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.hmpps.architecture.shared.cloudPlatform
 import uk.gov.justice.hmpps.architecture.shared.styles
 
 fun prisonWorkspace(): Workspace {
-  val hmpps_prisons = Enterprise("HMPPS Prisons")
+  val hmpps_prisons = Enterprise("HM Prison & Probation Service")
   val workspace = Workspace("Prison systems", "Systems related to the confinement of offenders").apply {
     model.setEnterprise(hmpps_prisons)
     setId(55246)

--- a/src/main/kotlin/prison/workspace.kt
+++ b/src/main/kotlin/prison/workspace.kt
@@ -1,11 +1,15 @@
 package uk.gov.justice.hmpps.architecture.prison
 
+import com.structurizr.model.Enterprise
 import com.structurizr.Workspace
 import uk.gov.justice.hmpps.architecture.shared.cloudPlatform
 import uk.gov.justice.hmpps.architecture.shared.styles
 
 fun prisonWorkspace(): Workspace {
-  val workspace = Workspace("Prison systems", "Systems related to the confinement of offenders")
+  val hmpps_prisons = Enterprise("HMPPS Prisons")
+  val workspace = Workspace("Prison systems", "Systems related to the confinement of offenders").apply {
+    model.setEnterprise(hmpps_prisons)
+  }
   workspace.id = 55246
 
   cloudPlatform(workspace.model)


### PR DESCRIPTION
## What does this pull request do?

- Adds the Prisons enterprise
- Sets `Location.Internal`/`Location.External` on some systems in the prison space
- Adds a description for the Drupal DB container to remove a build warning
- Copies view layout options from probation to improve the layout of the prisoner content hub diagrams

The use of `Enterprise` and `Location` allows Structurizr to place an organisational boundary around the people and containers.

System Landscape diagram:
<img width="1167" alt="Screenshot 2020-07-08 08 36 00" src="https://user-images.githubusercontent.com/464482/86894823-85a92300-c0fb-11ea-8497-98ac7f4b8a9f.png">

System Context diagram:
<img width="1167" alt="Screenshot 2020-07-08 08 35 28" src="https://user-images.githubusercontent.com/464482/86894882-98235c80-c0fb-11ea-8b16-59f862de4509.png">

## What is the intent behind these changes?

To demonstrate the use of Location to show organisational ownership, as an alternative to tags.
