### PR TITLE
Share Delius definition across HMPPS

### DIFF
--- a/src/main/kotlin/prison/model.kt
+++ b/src/main/kotlin/prison/model.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.hmpps.architecture.prison
 import com.structurizr.model.CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy
 import com.structurizr.model.Model
 
+import uk.gov.justice.hmpps.architecture.probation.Delius
+
 fun prisonModel(model: Model) {
   model.setImpliedRelationshipsStrategy(
       CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy())
@@ -10,7 +12,7 @@ fun prisonModel(model: Model) {
   val nomis = NOMIS(model)
 
   HmmpsAuth(model)
-  DELIUS(model)
+  Delius(model)
   NDH(model).system
   PATHFINDER(model)
 

--- a/src/main/kotlin/prison/pathfinder.kt
+++ b/src/main/kotlin/prison/pathfinder.kt
@@ -34,7 +34,7 @@ class PATHFINDER(model: Model) {
           uses(db, null)
           uses(model.getSoftwareSystemWithName("NOMIS")!!.getContainerWithName("Elite2 API")!!, "extract NOMIS offender data")
           uses(model.getSoftwareSystemWithName("NOMIS")!!.getContainerWithName("PrisonerSearch")!!, "to search for prisoners")
-          uses(model.getSoftwareSystemWithName("nDelius")!!.getContainerWithName("CommunityAPI")!!, "extract nDelius offender data")
+          uses(model.getSoftwareSystemWithName("nDelius")!!.getContainerWithName("Community API")!!, "extract nDelius offender data")
           uses(model.getSoftwareSystemWithName("nDelius")!!.getContainerWithName("OffenderSearch")!!, "to search for offenders")
           kubernetes.add(this)
         }

--- a/src/main/kotlin/prison/views.kt
+++ b/src/main/kotlin/prison/views.kt
@@ -43,7 +43,7 @@ fun prisonViews(model: Model, views: ViewSet) {
     add(model.getSoftwareSystemWithName("NOMIS")?.getContainerWithName("ElasticSearch store"))
     add(model.getSoftwareSystemWithName("NOMIS")?.getContainerWithName("PrisonerSearch"))
     add(model.getSoftwareSystemWithName("nDelius")?.getContainerWithName("nDelius database"))
-    add(model.getSoftwareSystemWithName("nDelius")?.getContainerWithName("CommunityAPI"))
+    add(model.getSoftwareSystemWithName("nDelius")?.getContainerWithName("Community API"))
     add(model.getSoftwareSystemWithName("nDelius")?.getContainerWithName("ElasticSearch store"))
     add(model.getSoftwareSystemWithName("nDelius")?.getContainerWithName("OffenderSearch"))
     add(model.getSoftwareSystemWithName("HMPPS Auth")!!)

--- a/src/main/kotlin/probation/delius.kt
+++ b/src/main/kotlin/probation/delius.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.hmpps.architecture.prison
+package uk.gov.justice.hmpps.architecture.probation
 
 import com.structurizr.model.Container
 import com.structurizr.model.Model
@@ -6,25 +6,14 @@ import com.structurizr.model.SoftwareSystem
 
 import uk.gov.justice.hmpps.architecture.shared.Tags
 
-class DELIUS(model: Model) {
+class Delius(model: Model) {
   val system: SoftwareSystem
-  val db: Container
-
-  companion object {
-    const val DATABASE_TAG = "database";
-    const val SOFTWARE_AS_A_SERVICE_TAG = "SAAS";
-  }
-
-  /**
-   *
-   */
 
   init {
-
     system = model.addSoftwareSystem("nDelius",
         "National Delius\nSupporting the management of offenders and delivering national reporting and performance monitoring data")
 
-    db = system.addContainer("nDelius database", null, "Oracle").apply {
+    val db = system.addContainer("nDelius database", null, "Oracle").apply {
       Tags.DATABASE.addTo(this)
       Tags.SOFTWARE_AS_A_SERVICE.addTo(this)
     }
@@ -36,18 +25,16 @@ class DELIUS(model: Model) {
           Tags.SOFTWARE_AS_A_SERVICE.addTo(this)
         }
 
-    system.addContainer("CommunityAPI",
+    system.addContainer("Community API",
         "API over the nDelius DB used by HMPPS Digital team applications and services", "Java")
         .apply {
           setUrl("https://github.com/ministryofjustice/community-api")
-          uses(db, "JDBC")
+          uses(db, "connects to", "JDBC")
         }
 
     system.addContainer("OffenderSearch",
-
         "API over the nDelius offender data held in Elasticsearch", "Java").apply {
       uses(elasticSearchStore, "Queries offender data from nDelius Elasticsearch Index")
     }
-
   }
 }

--- a/src/main/kotlin/probation/model.kt
+++ b/src/main/kotlin/probation/model.kt
@@ -31,7 +31,7 @@ fun probationModel(model: Model) {
 
   val caseNotesToProbation = model.addSoftwareSystem("Case Notes to Probation", "Polls for case notes and pushes them to probation systems")
   val crcSystem = model.addSoftwareSystem("CRC software systems", null).apply { Tags.PROVIDER.addTo(this) }
-  val delius = model.addSoftwareSystem("nDelius", "National Delius\nSupporting the management of offenders and delivering national reporting and performance monitoring data")
+  val delius = model.getSoftwareSystemWithName("nDelius")!!
   val epf = model.addSoftwareSystem("EPF", "Effective Proposal Framework\nPresents sentencing options to NPS staff in court who are providing sentencing advice to sentencers")
   val equip = model.addSoftwareSystem("EQuiP", "Central repository for all step-by-step business processes (in probation?)")
   val interventionsManager = model.addSoftwareSystem("IM", "Interventions Manager\nHolds records of interventions delivered to services users in the community")

--- a/src/main/kotlin/probation/workspace.kt
+++ b/src/main/kotlin/probation/workspace.kt
@@ -11,6 +11,7 @@ fun probationWorkspace(): Workspace {
   workspace.model.enterprise = Enterprise("Probation in HM Prison and Probation Service")
 
   cloudPlatform(workspace.model)
+  Delius(workspace.model)
   probationModel(workspace.model)
   probationViews(workspace.model, workspace.views)
   styles(workspace.views.configuration.styles)


### PR DESCRIPTION
## What does this pull request do?

We defined the "National Delius" software system in both packages and workspaces. This changeset moves DRYs that up by moving it to probation.

Slightly related change: `Community API` now has a space in its name, following the pattern of `Elite2 API`.

## What is the intent behind these changes?

To reduce duplication in the model by reusing elements.