### PR TITLE
Rename Elite2 API to Prison API

### DIFF
--- a/src/main/kotlin/prison/nomis.kt
+++ b/src/main/kotlin/prison/nomis.kt
@@ -15,7 +15,7 @@ class NOMIS private constructor() {
   companion object: HMPPSSoftwareSystem {
     lateinit var system: SoftwareSystem
     lateinit var db: Container
-    lateinit var elite2api: Container
+    lateinit var prisonApi: Container
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem("NOMIS", """
@@ -35,10 +35,11 @@ class NOMIS private constructor() {
         uses(db, "connects to", "JDBC")
       }
 
-      elite2api = system.addContainer("Elite2 API",
+      prisonApi = system.addContainer("Prison API",
           "API over the NOMIS DB used by Digital Prison team applications and services", "Java")
           .apply {
-            setUrl("https://github.com/ministryofjustice/elite2-api")
+            addProperty("previous-name", "Elite2 API")
+            setUrl("https://github.com/ministryofjustice/prison-api")
             uses(db, "connects to", "JDBC")
           }
 
@@ -65,7 +66,7 @@ class NOMIS private constructor() {
       }
 
       system.addContainer("NOMIS API (Deprecated)",
-          "(Deprecated) REST API for NOMIS which connects to Oracle DB. Deprecated - please use " + elite2api.getName() + " instead.",
+          "(Deprecated) REST API for NOMIS which connects to Oracle DB. Deprecated - please use " + prisonApi.getName() + " instead.",
           null).apply {
         setUrl("https://github.com/ministryofjustice/nomis-api")
         Tags.DEPRECATED.addTo(this)

--- a/src/main/kotlin/prison/nomis.kt
+++ b/src/main/kotlin/prison/nomis.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.hmpps.architecture.prison
 
+import com.structurizr.model.Container
 import com.structurizr.model.Location
 import com.structurizr.model.Model
-import com.structurizr.model.Container
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
 
@@ -32,14 +32,14 @@ class NOMIS private constructor() {
       system.addContainer("NOMIS Web Application",
           "Web Application fronting the NOMIS DB - used by Digital Prison team applications and services",
           "Weblogic App Sever").apply {
-        uses(db, "JDBC")
+        uses(db, "connects to", "JDBC")
       }
 
       elite2api = system.addContainer("Elite2 API",
           "API over the NOMIS DB used by Digital Prison team applications and services", "Java")
           .apply {
             setUrl("https://github.com/ministryofjustice/elite2-api")
-            uses(db, "JDBC")
+            uses(db, "connects to", "JDBC")
           }
 
       val elasticSearchStore = system.addContainer("ElasticSearch store",
@@ -61,7 +61,7 @@ class NOMIS private constructor() {
           null).apply {
         setUrl("https://github.com/ministryofjustice/custody-api")
         Tags.DEPRECATED.addTo(this)
-        uses(db, "JDBC")
+        uses(db, "connects to", "JDBC")
       }
 
       system.addContainer("NOMIS API (Deprecated)",
@@ -69,13 +69,13 @@ class NOMIS private constructor() {
           null).apply {
         setUrl("https://github.com/ministryofjustice/nomis-api")
         Tags.DEPRECATED.addTo(this)
-        uses(db, "JDBC")
+        uses(db, "connects to", "JDBC")
       }
 
       system.addContainer("Offender Events",
           "Publishes Events about offender change to Pub / Sub Topics.", "Java").apply {
         setUrl("https://github.com/ministryofjustice/offender-events")
-        uses(db, "JDBC")
+        uses(db, "connects to", "JDBC")
         CloudPlatform.sqs.add(this)
         CloudPlatform.sns.add(this)
         CloudPlatform.kubernetes.add(this)

--- a/src/main/kotlin/prison/pathfinder.kt
+++ b/src/main/kotlin/prison/pathfinder.kt
@@ -32,7 +32,7 @@ class PATHFINDER(model: Model) {
         .apply {
           Tags.WEB_BROWSER.addTo(this)
           uses(db, null)
-          uses(model.getSoftwareSystemWithName("NOMIS")!!.getContainerWithName("Elite2 API")!!, "extract NOMIS offender data")
+          uses(model.getSoftwareSystemWithName("NOMIS")!!.getContainerWithName("Prison API")!!, "extract NOMIS offender data")
           uses(model.getSoftwareSystemWithName("NOMIS")!!.getContainerWithName("PrisonerSearch")!!, "to search for prisoners")
           uses(model.getSoftwareSystemWithName("nDelius")!!.getContainerWithName("Community API")!!, "extract nDelius offender data")
           uses(model.getSoftwareSystemWithName("nDelius")!!.getContainerWithName("OffenderSearch")!!, "to search for offenders")

--- a/src/main/kotlin/prison/prisonerContentHub.kt
+++ b/src/main/kotlin/prison/prisonerContentHub.kt
@@ -28,7 +28,7 @@ class PrisonerContentHub private constructor() {
       this.model = model
 
       system = model.addSoftwareSystem(
-        "Prisoner Content Hub", 
+        "Prisoner Content Hub",
         """
         The Prisoner Content Hub is a platform for prisoners to access data, content and services supporting individual progression and freeing up staff time.
         """.trimIndent()).apply {
@@ -107,7 +107,7 @@ class PrisonerContentHub private constructor() {
     }
 
     override fun defineRelationships() {
-      contentHubFrontend.uses(NOMIS.elite2api, "lookup visits, canteen, etc.")
+      contentHubFrontend.uses(NOMIS.prisonApi, "lookup visits, canteen, etc.")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/prison/views.kt
+++ b/src/main/kotlin/prison/views.kt
@@ -16,7 +16,7 @@ fun prisonViews(model: Model, views: ViewSet) {
       "The container diagram for the Pathfinder System.").apply {
     addDefaultElements()
     add(model.getSoftwareSystemWithName("NOMIS")?.getContainerWithName("NOMIS database"))
-    add(model.getSoftwareSystemWithName("NOMIS")?.getContainerWithName("Elite2 API"))
+    add(model.getSoftwareSystemWithName("NOMIS")?.getContainerWithName("Prison API"))
     add(model.getSoftwareSystemWithName("NOMIS")?.getContainerWithName("ElasticSearch store"))
     add(model.getSoftwareSystemWithName("NOMIS")?.getContainerWithName("PrisonerSearch"))
     add(model.getSoftwareSystemWithName("nDelius")?.getContainerWithName("nDelius database"))


### PR DESCRIPTION
## What does this pull request do?

Renames Elite2 API to Prison API. The team renamed it on 3 July 2020.

## What is the intent behind these changes?

To keep the information up-to-date.