### PR TITLE
People should have the same text colour as systems

### DIFF
--- a/src/main/kotlin/shared/styles.kt
+++ b/src/main/kotlin/shared/styles.kt
@@ -6,15 +6,15 @@ import com.structurizr.view.Styles
 import uk.gov.justice.hmpps.architecture.shared.Tags
 
 fun styles(styles: Styles) {
-  styles.addElementStyle("Software System").color("#ffffff").background("#006699")
-  styles.addElementStyle("Person").shape(Shape.Person).color("#ffffff").background("#0099cc")
+  styles.addElementStyle("Software System").background("#aabbdd")
+  styles.addElementStyle("Person").shape(Shape.Person).background("#aabbdd")
 
   styles.addElementStyle(Tags.DATABASE.toString()).shape(Shape.Cylinder)
 
-  styles.addElementStyle(Tags.PRISON_SERVICE.toString()).color("#000000").background("#ffdf2d")
+  styles.addElementStyle(Tags.PRISON_SERVICE.toString()).background("#ffdf2d")
 
   styles.addElementStyle(Tags.WEB_BROWSER.toString()).shape(Shape.WebBrowser)
 
-  styles.addElementStyle(Tags.PROVIDER.toString()).color("#000000").background("#ccff99")
+  styles.addElementStyle(Tags.PROVIDER.toString()).background("#ccff99")
   styles.addElementStyle(Tags.DEPRECATED.toString()).background("#999999")
 }

--- a/src/main/kotlin/shared/styles.kt
+++ b/src/main/kotlin/shared/styles.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.hmpps.architecture.shared.Tags
 
 fun styles(styles: Styles) {
   styles.addElementStyle("Software System").color("#ffffff").background("#006699")
-  styles.addElementStyle("Person").shape(Shape.Person).background("#0099cc")
+  styles.addElementStyle("Person").shape(Shape.Person).color("#ffffff").background("#0099cc")
 
   styles.addElementStyle(Tags.DATABASE.toString()).shape(Shape.Cylinder)
 


### PR DESCRIPTION
## What does this pull request do?

Change the text colour of people to match systems.

| Before | After |
| --- | --- |
| <img width="300" src="https://user-images.githubusercontent.com/1526295/87686436-66a23500-c77c-11ea-92f6-8ef147f04ae4.png"/> | <img width="330" src="https://user-images.githubusercontent.com/1526295/88037751-391f0800-cb3d-11ea-8124-800e97591d18.png"/> |


## What is the intent behind these changes?

To make the text on `Person` elements more legible.