### PR TITLE
Group intervention teams together

### DIFF
--- a/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
+++ b/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
@@ -24,10 +24,7 @@ fun defineModelWithDeprecatedSyntax(model: Model) {
   val contractManager = model.addPerson("Contract Manager for CRCs", null)
   val courtAdmin = model.addPerson("NPS court administrator", null)
   val crcProgrammeManager = model.addPerson("CRC programme manager", "People who provide interventions on behalf of Community Rehabilitation Companies").apply { Tags.PROVIDER.addTo(this) }
-  val crcTreatmentManager = model.addPerson("CRC treatment manager", null).apply { Tags.PROVIDER.addTo(this) }
   val deliusSupport = model.addPerson("National Delius Support Team", null)
-  val interventionServices = model.addPerson("Intervention Services Team", "They accredit intervention programmes and do business development of the interventions.")
-  val npsProgrammeManager = model.addPerson("NPS programme manager", null)
   val sentencingPolicy = model.addPerson("Sentencing Policy", "Pseudo-team to capture sentencing policy meeting participants")
 
   val hmip = model.addPerson("HM Inspectorate of Probation", "Reports to the government on the effectiveness of work with people who offended to reduce reoffending and protect the public")
@@ -48,14 +45,10 @@ fun defineModelWithDeprecatedSyntax(model: Model) {
   courtAdmin.uses(prepareCaseForCourt, "captures court judgements in")
   ProbationPractitioners.crc.uses(oasys, "records offender risk (attendance, contact, etc.) and assessment in")
   crcProgrammeManager.interactsWith(deliusSupport, "opens tickets to update interventions")
-  crcTreatmentManager.uses(IM.system, "creates new interventions in")
   Delius.system.uses(oasys, "offender details, offence details, sentence info are copied into", "NDH")
   deliusSupport.uses(Delius.system, "administers everything in")
   deliusSupport.uses(Delius.system, "updates interventions in")
   EPF.projectManager.interactsWith(sentencingPolicy, "listens to owners of interventions for changes in policy")
-  interventionServices.interactsWith(EPF.projectManager, "provide programme suitability guide for accredited programme eligibility to")
-  interventionServices.uses(Delius.system, "creates new interventions in")
-  interventionServices.uses(IM.system, "creates new interventions in")
   Reporting.ndmis.uses(OffenderManagementInCustody.allocationManager, "sends extracts containing service user allocation to", "email")
   NOMIS.system.uses(Delius.system, "offender data is copied into", "NDH")
   NOMIS.system.uses(oasys, "offender data is coped into", "NDH")
@@ -63,7 +56,6 @@ fun defineModelWithDeprecatedSyntax(model: Model) {
   ProbationPractitioners.nps.uses(oasys, "records offender risk (attendance, contact, etc.) and assessment in")
   ProbationPractitioners.nps.uses(prepareCaseForCourt, "view case defendant details")
   ProbationPractitioners.nps.uses(wmt, "finds out their community case load by looking at")
-  npsProgrammeManager.uses(IM.system, "create new interventions in")
   oasys.uses(Delius.system, "assessment info, risk measures are copied into", "NDH")
   prepareCaseForCourt.uses(Delius.system, "get offender details from")
   prepareCaseForCourt.uses(oasys, "get offender assessment details from")

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -12,17 +12,18 @@ fun defineWorkspace(): Workspace {
   CloudPlatform.defineDeploymentNodes(workspace.model)
 
   val modelItems = listOf(
-    CRCSystem, 
-    Delius, 
-    EPF, 
-    EQuiP, 
-    IM, 
+    CRCSystem,
+    Delius,
+    EPF,
+    EQuiP,
+    IM,
+    InterventionTeams,
     NationalPrisonRadio,
-    NID, 
-    NOMIS, 
-    OffenderManagementInCustody, 
+    NID,
+    NOMIS,
+    OffenderManagementInCustody,
     PrisonerContentHub,
-    ProbationPractitioners, 
+    ProbationPractitioners,
     Reporting
   )
   modelItems.forEach { it.defineModelEntities(workspace.model) }

--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -47,8 +47,10 @@ class Delius private constructor() {
     }
 
     override fun defineRelationships() {
+      IM.system.uses(system, "pushes contact information of interest to", "IAPS")
       ProbationPractitioners.crc.uses(system, "records and reviews assessment decision, sentence plan in")
       ProbationPractitioners.nps.uses(system, "records and reviews assessment decision, sentence plan, pre-sentence report, referrals in")
+      InterventionTeams.interventionServicesTeam.uses(system, "creates new interventions in")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/EPF.kt
+++ b/src/main/kotlin/model/EPF.kt
@@ -27,6 +27,7 @@ class EPF private constructor() {
       projectManager.uses(system, "updates interventions table for discretionary services in")
       ProbationPractitioners.nps.uses(system, "enters court, location, offender needs, assessment score data to receive a shortlist of recommended interventions for Pre-Sentence Report Proposal from")
       ProbationPractitioners.nps.uses(system, "enters location, offender needs, assessment score data to receive recommended interventions for licence condition planning from")
+      InterventionTeams.interventionServicesTeam.interactsWith(projectManager, "provide programme suitability guide for accredited programme eligibility to")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/IM.kt
+++ b/src/main/kotlin/model/IM.kt
@@ -19,8 +19,10 @@ class IM private constructor() {
     }
 
     override fun defineRelationships() {
-      system.uses(Delius.system, "pushes contact information of interest to", "IAPS")
       Delius.system.uses(system, "pushes active sentence requirements or licence conditions which are of interest to IM to", "IAPS")
+      InterventionTeams.interventionServicesTeam.uses(system, "create new interventions in")
+      InterventionTeams.npsProgrammeManager.uses(system, "create new interventions in")
+      InterventionTeams.crcTreatmentManager.uses(system, "create new interventions in")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/InterventionTeams.kt
+++ b/src/main/kotlin/model/InterventionTeams.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.Person
+import com.structurizr.view.ViewSet
+
+class InterventionTeams private constructor() {
+  companion object : HMPPSSoftwareSystem {
+    lateinit var interventionServicesTeam: Person
+    lateinit var npsProgrammeManager: Person
+    lateinit var crcTreatmentManager: Person
+
+    override fun defineModelEntities(model: Model) {
+      interventionServicesTeam = model.addPerson(
+        "Intervention Services Team",
+        "They accredit intervention programmes and do business development of the interventions"
+      )
+      npsProgrammeManager = model.addPerson("NPS programme manager")
+      crcTreatmentManager = model.addPerson("CRC treatment manager")
+        .apply { Tags.PROVIDER.addTo(this) }
+    }
+
+    override fun defineRelationships() {
+    }
+
+    override fun defineViews(views: ViewSet) {
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Groups teams working on intervention development, design, running into a single model object called `InterventionTeams`. As a result, the interactions by those teams are now in the relevant systems.

## What is the intent behind these changes?

Make it easier to see which teams work on interventions.