### PR TITLE
Specify Intervention Manager interactions in more detail

### DIFF
--- a/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
+++ b/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
@@ -24,7 +24,6 @@ fun defineModelWithDeprecatedSyntax(model: Model) {
   val contractManager = model.addPerson("Contract Manager for CRCs", null)
   val courtAdmin = model.addPerson("NPS court administrator", null)
   val crcProgrammeManager = model.addPerson("CRC programme manager", "People who provide interventions on behalf of Community Rehabilitation Companies").apply { Tags.PROVIDER.addTo(this) }
-  val deliusSupport = model.addPerson("National Delius Support Team", null)
   val sentencingPolicy = model.addPerson("Sentencing Policy", "Pseudo-team to capture sentencing policy meeting participants")
 
   val hmip = model.addPerson("HM Inspectorate of Probation", "Reports to the government on the effectiveness of work with people who offended to reduce reoffending and protect the public")
@@ -44,10 +43,8 @@ fun defineModelWithDeprecatedSyntax(model: Model) {
   courtAdmin.uses(Delius.system, "records CAS decision, referrals in")
   courtAdmin.uses(prepareCaseForCourt, "captures court judgements in")
   ProbationPractitioners.crc.uses(oasys, "records offender risk (attendance, contact, etc.) and assessment in")
-  crcProgrammeManager.interactsWith(deliusSupport, "opens tickets to update interventions")
+  crcProgrammeManager.interactsWith(Delius.supportTeam, "opens tickets to update interventions")
   Delius.system.uses(oasys, "offender details, offence details, sentence info are copied into", "NDH")
-  deliusSupport.uses(Delius.system, "administers everything in")
-  deliusSupport.uses(Delius.system, "updates interventions in")
   EPF.projectManager.interactsWith(sentencingPolicy, "listens to owners of interventions for changes in policy")
   Reporting.ndmis.uses(OffenderManagementInCustody.allocationManager, "sends extracts containing service user allocation to", "email")
   NOMIS.system.uses(Delius.system, "offender data is copied into", "NDH")

--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -47,10 +47,10 @@ class Delius private constructor() {
     }
 
     override fun defineRelationships() {
-      IM.system.uses(system, "pushes contact information of interest to", "IAPS")
+      IM.system.uses(system, "pushes service user contact information to", "IAPS")
       ProbationPractitioners.crc.uses(system, "records and reviews assessment decision, sentence plan in")
       ProbationPractitioners.nps.uses(system, "records and reviews assessment decision, sentence plan, pre-sentence report, referrals in")
-      InterventionTeams.interventionServicesTeam.uses(system, "creates new interventions in")
+      InterventionTeams.interventionServicesTeam.uses(system, "creates new accredited programmes in")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Model
+import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
@@ -8,6 +9,7 @@ import com.structurizr.view.ViewSet
 class Delius private constructor() {
   companion object : HMPPSSoftwareSystem {
     lateinit var system: SoftwareSystem
+    lateinit var supportTeam: Person
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
@@ -16,6 +18,11 @@ class Delius private constructor() {
       ).apply {
         ProblemArea.GETTING_THE_RIGHT_REHABILITATION.addTo(this)
       }
+
+      supportTeam = model.addPerson(
+        "NDST",
+        "(National Delius Support Team) Team supporting changes to data in National Delius"
+      )
 
       val db = system.addContainer("nDelius database", null, "Oracle").apply {
         Tags.DATABASE.addTo(this)
@@ -50,7 +57,9 @@ class Delius private constructor() {
       IM.system.uses(system, "pushes service user contact information to", "IAPS")
       ProbationPractitioners.crc.uses(system, "records and reviews assessment decision, sentence plan in")
       ProbationPractitioners.nps.uses(system, "records and reviews assessment decision, sentence plan, pre-sentence report, referrals in")
-      InterventionTeams.interventionServicesTeam.uses(system, "creates new accredited programmes in")
+
+      InterventionTeams.interventionServicesTeam.interactsWith(supportTeam, "raises task to create or update an accredited programme with")
+      supportTeam.uses(system, "updates interventions in")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/IM.kt
+++ b/src/main/kotlin/model/IM.kt
@@ -13,14 +13,14 @@ class IM private constructor() {
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
-        "IM",
-        "(Interventions Manager) Schedules appointments and records service user progress on accredited programmes"
+        "Interventions Manager",
+        "(IM) Used to schedule accredited programmes and record service users' progress on them"
       ).apply {
         ProblemArea.GETTING_THE_RIGHT_REHABILITATION.addTo(this)
       }
 
       i2nTeam = model.addPerson(
-        "i2n",
+        "i2n (formerly Northgate)",
         "Provides and maintains the Intervention Manager service"
       ).apply {
         addProperty("previous-name", "Northgate")
@@ -30,8 +30,8 @@ class IM private constructor() {
 
     override fun defineRelationships() {
       Delius.system.uses(system, "pushes active sentence requirements or licence conditions to", "IAPS")
-      InterventionTeams.npsProgrammeManager.uses(system, "schedules accredited programme appointments and tracks service user attendance in")
-      InterventionTeams.crcTreatmentManager.uses(system, "schedules accredited programme appointments and tracks service user attendance in")
+      InterventionTeams.npsTreatmentManager.uses(system, "schedules accredited programme appointments, tracks service user attendance and evaluate service user progress in")
+      InterventionTeams.crcTreatmentManager.uses(system, "schedules accredited programme appointments, tracks service user attendance and evaluate service user progress in")
 
       Delius.supportTeam.interactsWith(i2nTeam, "notify an accredited programme is updated", "email")
       i2nTeam.uses(system, "creates new accredited programmes in")

--- a/src/main/kotlin/model/IM.kt
+++ b/src/main/kotlin/model/IM.kt
@@ -12,17 +12,17 @@ class IM private constructor() {
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
         "IM",
-        "Interventions Manager\nHolds records of interventions delivered to services users in the community"
+        "(Interventions Manager) Schedules appointments and records service user progress on accredited programmes"
       ).apply {
         ProblemArea.GETTING_THE_RIGHT_REHABILITATION.addTo(this)
       }
     }
 
     override fun defineRelationships() {
-      Delius.system.uses(system, "pushes active sentence requirements or licence conditions which are of interest to IM to", "IAPS")
-      InterventionTeams.interventionServicesTeam.uses(system, "create new interventions in")
-      InterventionTeams.npsProgrammeManager.uses(system, "create new interventions in")
-      InterventionTeams.crcTreatmentManager.uses(system, "create new interventions in")
+      Delius.system.uses(system, "pushes active sentence requirements or licence conditions to", "IAPS")
+      InterventionTeams.interventionServicesTeam.uses(system, "creates new accredited programmes in")
+      InterventionTeams.npsProgrammeManager.uses(system, "schedules accredited programme appointments and tracks service user attendance in")
+      InterventionTeams.crcTreatmentManager.uses(system, "schedules accredited programme appointments and tracks service user attendance in")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/IM.kt
+++ b/src/main/kotlin/model/IM.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Model
+import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
@@ -8,6 +9,7 @@ import com.structurizr.view.ViewSet
 class IM private constructor() {
   companion object : HMPPSSoftwareSystem {
     lateinit var system: SoftwareSystem
+    lateinit var i2nTeam: Person
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
@@ -16,18 +18,31 @@ class IM private constructor() {
       ).apply {
         ProblemArea.GETTING_THE_RIGHT_REHABILITATION.addTo(this)
       }
+
+      i2nTeam = model.addPerson(
+        "i2n",
+        "Provides and maintains the Intervention Manager service"
+      ).apply {
+        addProperty("previous-name", "Northgate")
+        Tags.PROVIDER.addTo(this)
+      }
     }
 
     override fun defineRelationships() {
       Delius.system.uses(system, "pushes active sentence requirements or licence conditions to", "IAPS")
-      InterventionTeams.interventionServicesTeam.uses(system, "creates new accredited programmes in")
       InterventionTeams.npsProgrammeManager.uses(system, "schedules accredited programme appointments and tracks service user attendance in")
       InterventionTeams.crcTreatmentManager.uses(system, "schedules accredited programme appointments and tracks service user attendance in")
+
+      Delius.supportTeam.interactsWith(i2nTeam, "notify an accredited programme is updated", "email")
+      i2nTeam.uses(system, "creates new accredited programmes in")
     }
 
     override fun defineViews(views: ViewSet) {
       views.createSystemContextView(system, "interventions-manager-context", null).apply {
         addDefaultElements()
+        add(i2nTeam)
+        add(Delius.supportTeam)
+        add(InterventionTeams.interventionServicesTeam)
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
       }
     }

--- a/src/main/kotlin/model/InterventionTeams.kt
+++ b/src/main/kotlin/model/InterventionTeams.kt
@@ -7,7 +7,7 @@ import com.structurizr.view.ViewSet
 class InterventionTeams private constructor() {
   companion object : HMPPSSoftwareSystem {
     lateinit var interventionServicesTeam: Person
-    lateinit var npsProgrammeManager: Person
+    lateinit var npsTreatmentManager: Person
     lateinit var crcTreatmentManager: Person
 
     override fun defineModelEntities(model: Model) {
@@ -15,7 +15,7 @@ class InterventionTeams private constructor() {
         "Intervention Services Team",
         "They accredit intervention programmes and do business development of the interventions"
       )
-      npsProgrammeManager = model.addPerson("NPS programme manager")
+      npsTreatmentManager = model.addPerson("NPS treatment manager")
       crcTreatmentManager = model.addPerson("CRC treatment manager")
         .apply { Tags.PROVIDER.addTo(this) }
     }


### PR DESCRIPTION
## What does this pull request do?

Clarifies the interactions between the teams using the Interventions Manager system, specifying that it's used for accredited programmes, not all interventions.

This pull request also defines the role of supporting teams who handle the accredited programme changes.

| Before | After |
| --- | --- |
| ![structurizr-56937-interventions-manager-context](https://user-images.githubusercontent.com/1526295/89315671-0a437e80-d673-11ea-9e9e-753995cd4d00.png) | ![structurizr-56937-interventions-manager-context](https://user-images.githubusercontent.com/1526295/89905073-97418700-dbe1-11ea-90fc-316b726ce7ea.png) |


## What is the intent behind these changes?

To be more specific on what is happening and getting closer to what _actually_ is happening. 😅

Source of change: process maps done by our business analysts and my notes from previous discussions.