### PR TITLE
Use implied relationships for all relationships

### DIFF
--- a/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
+++ b/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
@@ -1,13 +1,8 @@
 package uk.gov.justice.hmpps.architecture
 
-import com.structurizr.model.CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy
 import com.structurizr.model.Model
 
 fun defineModelWithDeprecatedSyntax(model: Model) {
-  model.setImpliedRelationshipsStrategy(
-    CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy()
-  )
-
   // lifted from prison model
   val spo = model.addPerson("Senior Prison Offender Manager", "manages service users and offender managers")
   val pom = model.addPerson("Prison Offender Manager", "responsible for the service users in their prison")

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.Workspace
+import com.structurizr.model.CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy
 import com.structurizr.model.Enterprise
 
 fun defineWorkspace(): Workspace {
@@ -8,6 +9,10 @@ fun defineWorkspace(): Workspace {
   val workspace = Workspace(enterprise.name, "Systems related to the custody and probation of offenders")
   workspace.id = 56937
   workspace.model.enterprise = enterprise
+
+  workspace.model.setImpliedRelationshipsStrategy(
+    CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy()
+  )
 
   CloudPlatform.defineDeploymentNodes(workspace.model)
 


### PR DESCRIPTION
## What does this pull request do?

Automatically propagates C4 person-to-container relationships to C4 person-to-system relationships.

This propagation is useful to show who uses our systems to an audience outside the developer teams.

I noticed this was not happening when I was looking through the system context diagrams.

| Before | After |
| --- | --- |
| ![structurizr-56937-prisonerContentHubSystemContext-before](https://user-images.githubusercontent.com/1526295/89526465-b73b0a00-d7df-11ea-9f47-276d47d9dcf5.png) | ![structurizr-56937-prisonerContentHubSystemContext-after](https://user-images.githubusercontent.com/1526295/89526456-b4d8b000-d7df-11ea-8ccf-9f7fee2c2493.png) |

For reference, the container diagram is:

![structurizr-56937-prisonerContentHubContainer](https://user-images.githubusercontent.com/1526295/89526780-2fa1cb00-d7e0-11ea-97b0-16ea41ffb581.png)


## What is the intent behind these changes?

Some of the person-to-container relationships that are defined in the `defineModelEntities` were not propagating to person-to-system relationships.

This change applies the relationship propagation setting at the beginning of the workspace definition instead of in `defineModelWithDeprecatedSyntax()`.