### PR TITLE
Prisoner Content Hub media proxy only proxies NPR

### DIFF
--- a/src/main/kotlin/model/PrisonerContentHub.kt
+++ b/src/main/kotlin/model/PrisonerContentHub.kt
@@ -67,8 +67,7 @@ class PrisonerContentHub private constructor() {
         CloudPlatform.kubernetes.add(this)
       }
 
-      frontendProxy = system.addContainer("Nginx ingress", "Proxy for frontend and media on external domains not accessible to prison users", "Nginx").apply {
-        uses(contentHubFrontend, "Proxies requests to")
+      frontendProxy = system.addContainer("Nginx ingress", "Proxy for media on external domains not accessible to prison users", "Nginx").apply {
         CloudPlatform.kubernetes.add(this)
       }
 
@@ -87,12 +86,14 @@ class PrisonerContentHub private constructor() {
       }
 
       model.addPerson("Prisoner", "A prisoner over 18 years old, held in the public prison estate").apply {
-        uses(frontendProxy, "Views videos, audio programmes, site updates, and rehabilitative material")
+        uses(contentHubFrontend, "Views videos, audio programmes, site updates, and rehabilitative material")
+        uses(frontendProxy, "Listens to National Prison Radio live stream")
         setLocation(Location.External)
       }
 
       model.addPerson("Young Offender", "A person under 18, held in a Young Offender Institute").apply {
-        uses(frontendProxy, "Views videos, audio programmes, site updates, and rehabilitative material")
+        uses(contentHubFrontend, "Views videos, audio programmes, site updates, and rehabilitative material")
+        uses(frontendProxy, "Listens to National Prison Radio live stream")
         setLocation(Location.External)
       }
 


### PR DESCRIPTION
## What does this pull request do?

Moves the Prisoner Content Hub NPR proxy to only proxy NPR requests, removing it from the "frontend"flow.

This proxy has been refactored to reduce the surprise factor of proxying certain paths off to different services. We now use domain separation to silo all our proxies, separating that from the rest of the frontend (i.e. media-proxy.content-hub.prisoner.service.justice.gov.uk/npr-stream,  rather than cookhamwood.content-hub.prisoner.service.justice.gov.uk/npr-stream).

#### Before
![structurizr-56937-prisonerContentHubContainer_before](https://user-images.githubusercontent.com/464482/89876129-25077d00-dbb6-11ea-8894-2166e5cefb98.png)

#### After 
![structurizr-56937-prisonerContentHubContainer](https://user-images.githubusercontent.com/464482/89876147-29cc3100-dbb6-11ea-8eb5-0d430f291f25.png)


## What is the intent behind these changes?

To reflect changes to the system that have just been made.