### PR TITLE
Move contract/programme managers to InterventionTeams

### DIFF
--- a/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
+++ b/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
@@ -16,9 +16,7 @@ fun defineModelWithDeprecatedSyntax(model: Model) {
   pom.uses(OffenderManagementInCustody.allocationManager, "look at service users who need handing over to community in")
 
   // lifted from probation model
-  val contractManager = model.addPerson("Contract Manager for CRCs", null)
   val courtAdmin = model.addPerson("NPS court administrator", null)
-  val crcProgrammeManager = model.addPerson("CRC programme manager", "People who provide interventions on behalf of Community Rehabilitation Companies").apply { Tags.PROVIDER.addTo(this) }
   val sentencingPolicy = model.addPerson("Sentencing Policy", "Pseudo-team to capture sentencing policy meeting participants")
 
   val hmip = model.addPerson("HM Inspectorate of Probation", "Reports to the government on the effectiveness of work with people who offended to reduce reoffending and protect the public")
@@ -34,11 +32,9 @@ fun defineModelWithDeprecatedSyntax(model: Model) {
   probationCaseSampler.setUrl("https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/1989181486/HMIP+Case+Sampling")
 
   caseNotesToProbation.uses(Delius.system, "pushes case notes to")
-  contractManager.interactsWith(EPF.projectManager, "sends a signed off version of the CRC's Discretionary Services rate card brochure to")
   courtAdmin.uses(Delius.system, "records CAS decision, referrals in")
   courtAdmin.uses(prepareCaseForCourt, "captures court judgements in")
   ProbationPractitioners.crc.uses(oasys, "records offender risk (attendance, contact, etc.) and assessment in")
-  crcProgrammeManager.interactsWith(Delius.supportTeam, "opens tickets to update interventions")
   Delius.system.uses(oasys, "offender details, offence details, sentence info are copied into", "NDH")
   EPF.projectManager.interactsWith(sentencingPolicy, "listens to owners of interventions for changes in policy")
   Reporting.ndmis.uses(OffenderManagementInCustody.allocationManager, "sends extracts containing service user allocation to", "email")

--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -59,6 +59,7 @@ class Delius private constructor() {
       ProbationPractitioners.nps.uses(system, "records and reviews assessment decision, sentence plan, pre-sentence report, referrals in")
 
       InterventionTeams.interventionServicesTeam.interactsWith(supportTeam, "raises task to create or update an accredited programme with")
+      InterventionTeams.crcProgrammeManager.interactsWith(supportTeam, "raises task to update interventions with")
       supportTeam.uses(system, "updates interventions in")
     }
 

--- a/src/main/kotlin/model/EPF.kt
+++ b/src/main/kotlin/model/EPF.kt
@@ -28,6 +28,7 @@ class EPF private constructor() {
       ProbationPractitioners.nps.uses(system, "enters court, location, offender needs, assessment score data to receive a shortlist of recommended interventions for Pre-Sentence Report Proposal from")
       ProbationPractitioners.nps.uses(system, "enters location, offender needs, assessment score data to receive recommended interventions for licence condition planning from")
       InterventionTeams.interventionServicesTeam.interactsWith(projectManager, "provide programme suitability guide for accredited programme eligibility to")
+      InterventionTeams.contractManagerForCRC.interactsWith(projectManager, "sends a signed off version of the CRC's Discretionary Services rate card brochure to")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/InterventionTeams.kt
+++ b/src/main/kotlin/model/InterventionTeams.kt
@@ -8,7 +8,9 @@ class InterventionTeams private constructor() {
   companion object : HMPPSSoftwareSystem {
     lateinit var interventionServicesTeam: Person
     lateinit var npsTreatmentManager: Person
+    lateinit var contractManagerForCRC: Person
     lateinit var crcTreatmentManager: Person
+    lateinit var crcProgrammeManager: Person
 
     override fun defineModelEntities(model: Model) {
       interventionServicesTeam = model.addPerson(
@@ -16,8 +18,17 @@ class InterventionTeams private constructor() {
         "They accredit intervention programmes and do business development of the interventions"
       )
       npsTreatmentManager = model.addPerson("NPS treatment manager")
+      contractManagerForCRC = model.addPerson("Contract Manager for CRCs")
+
       crcTreatmentManager = model.addPerson("CRC treatment manager")
         .apply { Tags.PROVIDER.addTo(this) }
+
+      crcProgrammeManager = model.addPerson(
+        "CRC programme manager",
+        "People who provide interventions on behalf of Community Rehabilitation Companies"
+      ).apply { Tags.PROVIDER.addTo(this) }
+
+      crcProgrammeManager.interactsWith(contractManagerForCRC, "sends rate card brochure to")
     }
 
     override fun defineRelationships() {


### PR DESCRIPTION
## What does this pull request do?

Consolidate other intervention-related roles to the `InterventionTeams` class.

One of the labels is slightly rephrased. No other changes in the model and diagrams.

## What is the intent behind these changes?

Their roles are tied to delivering interventions, so they belong to that group.