### PR TITLE
Add probation teams API (and APIDocs)

### DIFF
--- a/src/main/kotlin/APIDocs.kt
+++ b/src/main/kotlin/APIDocs.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Element
+
+class APIDocs(url: String) {
+  val url: String = url
+
+  fun addTo(element: Element) {
+    element.addProperty("api-docs-url", url)
+  }
+}

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -40,6 +40,7 @@ fun defineWorkspace(): Workspace {
     PrisonVisitsBooking,
     ProbationCaseSampler,
     ProbationPractitioners,
+    ProbationTeamsService,
     Reporting
   )
   modelItems.forEach { it.defineModelEntities(workspace.model) }

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -27,6 +27,7 @@ fun defineWorkspace(): Workspace {
     HMPPSAuth,
     IM,
     InterventionTeams,
+    Licences,
     MoJSignOn,
     NationalPrisonRadio,
     NDH,

--- a/src/main/kotlin/model/HMPPSAuth.kt
+++ b/src/main/kotlin/model/HMPPSAuth.kt
@@ -9,7 +9,7 @@ import com.structurizr.view.ViewSet
 class HMPPSAuth private constructor() {
   companion object : HMPPSSoftwareSystem {
     lateinit var system: SoftwareSystem
-    protected lateinit var app: Container
+    lateinit var app: Container
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem("HMPPS Auth", "Allows users to login into digital services").apply {
@@ -21,6 +21,7 @@ class HMPPSAuth private constructor() {
         "OAuth2 server integrating with NOMIS database, nDelius (via community api) and an auth database for storing external users",
         "Spring Boot + Java"
       ).apply {
+        APIDocs("https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/swagger-ui.html").addTo(this)
         setUrl("https://github.com/ministryofjustice/hmpps-auth")
       }
 

--- a/src/main/kotlin/model/Licences.kt
+++ b/src/main/kotlin/model/Licences.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.ViewSet
+
+class Licences private constructor() {
+  companion object : HMPPSSoftwareSystem {
+    lateinit var system: SoftwareSystem
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem("Licences", "This system is a stub. Please help us expand it.")
+    }
+
+    override fun defineRelationships() {
+      system.uses(ProbationTeamsService.api, "retrieves and updates probation areas and Local Delivery Unit 'functional' mailboxes in")
+    }
+
+    override fun defineViews(views: ViewSet) {
+    }
+  }
+}

--- a/src/main/kotlin/model/ProbationTeamsService.kt
+++ b/src/main/kotlin/model/ProbationTeamsService.kt
@@ -19,7 +19,7 @@ class ProbationTeamsService private constructor() {
       )
 
       api = system.addContainer("API", "API", "Kotlin + Spring Boot").apply {
-        APIDocs("https://probation-teams-preprod.prison.service.justice.gov.uk/swagger-ui.html").addTo(this)
+        APIDocs("https://probation-teams-dev.prison.service.justice.gov.uk/swagger-ui/index.html").addTo(this)
         setUrl("https://github.com/ministryofjustice/probation-teams")
       }
 

--- a/src/main/kotlin/model/ProbationTeamsService.kt
+++ b/src/main/kotlin/model/ProbationTeamsService.kt
@@ -1,0 +1,40 @@
+
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.AutomaticLayout
+import com.structurizr.view.ViewSet
+
+class ProbationTeamsService private constructor() {
+  companion object : HMPPSSoftwareSystem {
+    lateinit var system: SoftwareSystem
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem(
+        "Probation team contact and reference service",
+        "Exposes probation areas and Local Delivery Unit 'functional' mailboxes as an API"
+      )
+
+      val api = system.addContainer("API", "API", "Kotlin + Spring Boot").apply {
+        setUrl("https://github.com/ministryofjustice/probation-teams")
+      }
+
+      val db = system.addContainer("Database", "Storage for probation areas and Local Delivery Unit 'functional' mailboxes", "PostgreSQL").apply {
+        Tags.DATABASE.addTo(this)
+      }
+
+      api.uses(db, "connects to")
+    }
+
+    override fun defineRelationships() {
+    }
+
+    override fun defineViews(views: ViewSet) {
+      views.createContainerView(system, "probation-teams-container", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/model/ProbationTeamsService.kt
+++ b/src/main/kotlin/model/ProbationTeamsService.kt
@@ -1,6 +1,7 @@
 
 package uk.gov.justice.hmpps.architecture
 
+import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
@@ -9,6 +10,7 @@ import com.structurizr.view.ViewSet
 class ProbationTeamsService private constructor() {
   companion object : HMPPSSoftwareSystem {
     lateinit var system: SoftwareSystem
+    lateinit var api: Container
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
@@ -16,7 +18,7 @@ class ProbationTeamsService private constructor() {
         "Exposes probation areas and Local Delivery Unit 'functional' mailboxes as an API"
       )
 
-      val api = system.addContainer("API", "API", "Kotlin + Spring Boot").apply {
+      api = system.addContainer("API", "API", "Kotlin + Spring Boot").apply {
         APIDocs("https://probation-teams-preprod.prison.service.justice.gov.uk/swagger-ui.html").addTo(this)
         setUrl("https://github.com/ministryofjustice/probation-teams")
       }

--- a/src/main/kotlin/model/ProbationTeamsService.kt
+++ b/src/main/kotlin/model/ProbationTeamsService.kt
@@ -31,6 +31,7 @@ class ProbationTeamsService private constructor() {
     }
 
     override fun defineRelationships() {
+      api.uses(HMPPSAuth.app, "validates API tokens via", "JWK")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/ProbationTeamsService.kt
+++ b/src/main/kotlin/model/ProbationTeamsService.kt
@@ -17,6 +17,7 @@ class ProbationTeamsService private constructor() {
       )
 
       val api = system.addContainer("API", "API", "Kotlin + Spring Boot").apply {
+        APIDocs("https://probation-teams-preprod.prison.service.justice.gov.uk/swagger-ui.html").addTo(this)
         setUrl("https://github.com/ministryofjustice/probation-teams")
       }
 


### PR DESCRIPTION
## What does this pull request do?

Adds the https://github.com/ministryofjustice/probation-teams API to the model.

### API docs
This pull request introduces the `APIDocs` class, which sets the Structurizr property `api-docs-url`. Please refer to the full details in ba50bf5ce3c65f245ff73859e9e9f98347e8d615.

## What is the intent behind these changes?

To make sure we can discover all APIs from this repository.

## Outstanding questions

- [x] Who uses this API (systems or people)
  - licences app
- [x] How do we link to API docs?
  - Please see ba50bf5ce3c65f245ff73859e9e9f98347e8d615
- [x] How do we make APIs easily discoverable in the model? (Tag? `API.addTo(this)`?)
  - I think the `APIDocs` object solves this -- anything with an API docs link is an API.