### PR TITLE
Define offender-assessments-api

### DIFF
--- a/src/main/kotlin/model/OASys.kt
+++ b/src/main/kotlin/model/OASys.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.hmpps.architecture
 
+import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
@@ -7,9 +8,24 @@ import com.structurizr.view.ViewSet
 class OASys private constructor() {
   companion object : HMPPSSoftwareSystem {
     lateinit var system: SoftwareSystem
+    lateinit var assessmentsApi: Container
 
     override fun defineModelEntities(model: Model) {
-      system = model.addSoftwareSystem("Offender Assessment System", "(OASys) Assesses the risks and needs of offenders")
+      system = model.addSoftwareSystem("Offender Assessment System", "(OASys) Assesses the risks and needs of offenders").apply {
+        setUrl("https://dsdmoj.atlassian.net/wiki/spaces/~474366104/pages/2046820357/OASys+Overview")
+      }
+
+      val oracleApp = system.addContainer("Case Management System", "Assesses the risks and needs of offenders", "Oracle APEX")
+
+      assessmentsApi = system.addContainer("Assessments API", "REST access to the OASYS Oracle DB offender assessment information", "Java + Spring Boot").apply {
+        setUrl("https://github.com/ministryofjustice/offender-assessments-api")
+        APIDocs("http://assessments-api-dev.ngm7p4zgik.eu-west-2.elasticbeanstalk.com/swagger-ui.html").addTo(this)
+      }
+
+      val db = system.addContainer("Assessments Database", null, "Oracle")
+
+      oracleApp.uses(db, "connects to")
+      assessmentsApi.uses(db, "connects to", "JDBC")
     }
 
     override fun defineRelationships() {

--- a/src/main/kotlin/model/PrepareCaseForCourt.kt
+++ b/src/main/kotlin/model/PrepareCaseForCourt.kt
@@ -92,9 +92,7 @@ class PrepareCaseForCourt private constructor() {
 
       courtCaseService.uses(Delius.communityApi, "Gets offender details from")
       courtCaseMatcher.uses(Delius.offenderSearch, "Matches defendants to known offenders")
-
-      // TODO Model OASys & link to Offender Assessment API
-      courtCaseService.uses(OASys.system, "get offender assessment details from")
+      courtCaseService.uses(OASys.assessmentsApi, "get offender assessment details from")
 
       CourtUsers.courtAdministrator.uses(prepareCaseUI, "prepares cases for sentencing")
       ProbationPractitioners.nps.uses(prepareCaseUI, "views case defendant details")


### PR DESCRIPTION
## What does this pull request do?

Defines https://github.com/ministryofjustice/offender-assessments-api in the model.

It's a crucial API exposing assessment data from the OASys database. It's on the same level as `community-api` (Delius) and `prison-api` (NOMIS).

## What is the intent behind these changes?

To make sure we have all widely used APIs documented.