### PR TITLE
Add GitHub and API docs URLs to the probation offender search service

### DIFF
--- a/src/main/kotlin/defineViews.kt
+++ b/src/main/kotlin/defineViews.kt
@@ -35,12 +35,12 @@ fun defineViews(model: Model, views: ViewSet) {
     add(NOMIS.db)
     add(NOMIS.prisonApi)
     add(NOMIS.system.getContainerWithName("ElasticSearch store"))
-    add(NOMIS.system.getContainerWithName("PrisonerSearch"))
+    add(NOMIS.offenderSearch)
     add(Delius.system.getContainerWithName("nDelius database"))
-    add(Delius.system.getContainerWithName("Community API"))
+    add(Delius.communityApi)
     add(Delius.system.getContainerWithName("ElasticSearch store"))
-    add(Delius.system.getContainerWithName("OffenderSearch"))
-    add(model.getSoftwareSystemWithName("HMPPS Auth")!!)
+    add(Delius.offenderSearch)
+    add(HMPPSAuth.system)
     enableAutomaticLayout()
     externalSoftwareSystemBoundariesVisible = true
   }
@@ -51,7 +51,7 @@ fun defineViews(model: Model, views: ViewSet) {
     addDefaultElements()
     add(NOMIS.system)
     add(Delius.system)
-    add(model.getSoftwareSystemWithName("HMPPS Auth")!!)
+    add(HMPPSAuth.system)
     enableAutomaticLayout()
     isEnterpriseBoundaryVisible = false
   }

--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -49,9 +49,12 @@ class Delius private constructor() {
       }
 
       offenderSearch = system.addContainer(
-        "OffenderSearch",
-        "API over the nDelius offender data held in Elasticsearch", "Java"
+        "Probation Offender Search",
+        "API over the nDelius offender data held in Elasticsearch",
+        "Java"
       ).apply {
+        APIDocs("https://probation-offender-search.hmpps.service.justice.gov.uk/swagger-ui.html").addTo(this)
+        setUrl("https://github.com/ministryofjustice/probation-offender-search")
         uses(elasticSearchStore, "Queries offender data from nDelius Elasticsearch Index")
       }
     }

--- a/src/main/kotlin/model/NOMIS.kt
+++ b/src/main/kotlin/model/NOMIS.kt
@@ -11,6 +11,7 @@ class NOMIS private constructor() {
   companion object : HMPPSSoftwareSystem {
     lateinit var system: SoftwareSystem
     lateinit var db: Container
+    lateinit var offenderSearch: Container
     lateinit var prisonApi: Container
 
     override fun defineModelEntities(model: Model) {
@@ -45,14 +46,13 @@ class NOMIS private constructor() {
       val elasticSearchStore = system.addContainer(
         "ElasticSearch store",
         "Data store for NOMIS content", "ElasticSearch"
-      )
-        .apply {
-          Tags.DATABASE.addTo(this)
-          Tags.SOFTWARE_AS_A_SERVICE.addTo(this)
-          CloudPlatform.elasticsearch.add(this)
-        }
+      ).apply {
+        Tags.DATABASE.addTo(this)
+        Tags.SOFTWARE_AS_A_SERVICE.addTo(this)
+        CloudPlatform.elasticsearch.add(this)
+      }
 
-      system.addContainer(
+      offenderSearch = system.addContainer(
         "PrisonerSearch", "API over the NOMIS prisoner data held in Elasticsearch",
         "Kotlin"
       ).apply {

--- a/src/main/kotlin/model/Pathfinder.kt
+++ b/src/main/kotlin/model/Pathfinder.kt
@@ -33,10 +33,10 @@ class Pathfinder(model: Model) {
     ).apply {
       Tags.WEB_BROWSER.addTo(this)
       uses(db, null)
-      uses(model.getSoftwareSystemWithName("NOMIS")!!.getContainerWithName("Prison API")!!, "extract NOMIS offender data")
-      uses(model.getSoftwareSystemWithName("NOMIS")!!.getContainerWithName("PrisonerSearch")!!, "to search for prisoners")
-      uses(model.getSoftwareSystemWithName("nDelius")!!.getContainerWithName("Community API")!!, "extract nDelius offender data")
-      uses(model.getSoftwareSystemWithName("nDelius")!!.getContainerWithName("OffenderSearch")!!, "to search for offenders")
+      uses(NOMIS.prisonApi, "extract NOMIS offender data")
+      uses(NOMIS.offenderSearch, "to search for prisoners")
+      uses(Delius.communityApi, "extract nDelius offender data")
+      uses(Delius.offenderSearch, "to search for offenders")
       kubernetes.add(this)
     }
 
@@ -49,30 +49,28 @@ class Pathfinder(model: Model) {
       kubernetes.add(this)
     }
 
-    val hmppsAuth: SoftwareSystem = model.getSoftwareSystemWithName("HMPPS Auth")!!
-
     val pPrisonPreventLead = model.addPerson("Prison Prevent Lead", "They case manage Pathfinder Nominals in custody")
     pPrisonPreventLead.uses(webApp, "Visits pathfinder app to manage their local prison(s) caseload", "HTTPS")
-    pPrisonPreventLead.uses(hmppsAuth, "Login")
+    pPrisonPreventLead.uses(HMPPSAuth.system, "Login")
 
     val pRegionalPrisonPreventLead = model.addPerson("Regional Prison Prevent Lead", "They case manage a region of Pathfinder Nominals in custody")
     pRegionalPrisonPreventLead.uses(webApp, "Visits pathfinder app to manage their Regional prisons caseload", "HTTPS")
-    pRegionalPrisonPreventLead.uses(hmppsAuth, "Login")
+    pRegionalPrisonPreventLead.uses(HMPPSAuth.system, "Login")
 
     val pProbationOffenderManager = model.addPerson("Probation Offender Manager", "They case manage Pathfinder Nominals in the community")
     pProbationOffenderManager.uses(webApp, "Visits pathfinder app to manage their community caseload", "HTTPS")
-    pProbationOffenderManager.uses(hmppsAuth, "Login")
+    pProbationOffenderManager.uses(HMPPSAuth.system, "Login")
 
     val pRegionalPoliceUser = model.addPerson("Regional Police User", "They access limited regional data of Pathfinder Nominals")
     pRegionalPoliceUser.uses(webApp, "Visits pathfinder app to manage offenders in their region due for release", "HTTPS")
-    pRegionalPoliceUser.uses(hmppsAuth, "Login")
+    pRegionalPoliceUser.uses(HMPPSAuth.system, "Login")
 
     val pNationalPoliceUser = model.addPerson("National Police User", "They access limited National data of Pathfinder Nominals")
     pNationalPoliceUser.uses(webApp, "Visits pathfinder app to manage offenders nationally due for release", "HTTPS")
-    pNationalPoliceUser.uses(hmppsAuth, "Login")
+    pNationalPoliceUser.uses(HMPPSAuth.system, "Login")
 
     val pNationalIntelligenceUnitUser = model.addPerson("National Prison User", "They have access to all Pathfinder nominals")
     pNationalIntelligenceUnitUser.uses(webApp, "Visits pathfinder app to manage the performance of the service", "HTTPS")
-    pNationalIntelligenceUnitUser.uses(hmppsAuth, "Login")
+    pNationalIntelligenceUnitUser.uses(HMPPSAuth.system, "Login")
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Adds GitHub and API docs URLs to the probation offender search service.

Please review commit-by-commit, the last commit changes the way of referencing C4 elements as the first commit renames an element:

- from `model.getSoftwareSystemByName("something")`
- to `ModelObject.something`

## What is the intent behind these changes?

To have GitHub and API docs links available on as many items as possible.