### PR TITLE
Publish API documentation to Structurizr

### DIFF
--- a/exports/.gitignore
+++ b/exports/.gitignore
@@ -2,3 +2,6 @@
 structurizr-*.json
 structurizr-*.puml
 structurizr-*.png
+
+# generated documentation
+docs/

--- a/src/main/kotlin/defineDocumentation.kt
+++ b/src/main/kotlin/defineDocumentation.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.Workspace
+import com.structurizr.documentation.AutomaticDocumentationTemplate
+import com.structurizr.model.Container
+import com.structurizr.model.Model
+import java.io.File
+import java.io.PrintWriter
+
+fun defineDocumentation(workspace: Workspace) {
+  val docsRoot = File(App.EXPORT_LOCATION, "docs/")
+  docsRoot.mkdirs()
+
+  val w = File(docsRoot, "apidocs.md").printWriter()
+  writeAPIs(w, workspace.model)
+  w.close()
+
+  val template = AutomaticDocumentationTemplate(workspace)
+  template.addSections(docsRoot)
+}
+
+private fun writeAPIs(w: PrintWriter, model: Model) {
+  w.println("## Published APIs")
+  w.println("")
+
+  val apis = model.softwareSystems
+    .sortedBy { it.name.toLowerCase() }
+    .flatMap { it.containers }
+    .filter { it.properties.get("api-docs-url") != null }
+  w.println("| Software System | API name | Links |")
+  w.println("| --- | --- | --- |")
+  apis.forEach { writeAPI(w, it) }
+}
+
+private fun writeAPI(w: PrintWriter, apiContainer: Container) {
+  w.print("| ")
+  w.print(apiContainer.softwareSystem.name)
+
+  w.print("| ")
+  w.print(apiContainer.name)
+
+  w.print("| ")
+  val githubLink = apiContainer.url
+  val apidocsLink = apiContainer.properties.get("api-docs-url")
+  w.print(" [GitHub](%s)".format(githubLink))
+  w.print(" [APIdocs](%s)".format(apidocsLink))
+
+  w.println("|")
+}

--- a/src/main/kotlin/defineDocumentation.kt
+++ b/src/main/kotlin/defineDocumentation.kt
@@ -27,8 +27,8 @@ private fun writeAPIs(w: PrintWriter, model: Model) {
     .sortedBy { it.name.toLowerCase() }
     .flatMap { it.containers }
     .filter { it.properties.get("api-docs-url") != null }
-  w.println("| Software System | API name | Links |")
-  w.println("| --- | --- | --- |")
+  w.println("| Software System | API name | Purpose | Links |")
+  w.println("| --- | --- | --- | --- |")
   apis.forEach { writeAPI(w, it) }
 }
 
@@ -38,6 +38,9 @@ private fun writeAPI(w: PrintWriter, apiContainer: Container) {
 
   w.print("| ")
   w.print(apiContainer.name)
+
+  w.print("| ")
+  w.print(apiContainer.description)
 
   w.print("| ")
   val githubLink = apiContainer.url

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -53,5 +53,7 @@ fun defineWorkspace(): Workspace {
   defineViews(workspace.model, workspace.views)
   defineStyles(workspace.views.configuration.styles)
 
+  defineDocumentation(workspace)
+
   return workspace
 }


### PR DESCRIPTION
## What does this pull request do?

Generates and publishes a list of APIs that are tagged with `APIDocs` in the model to https://structurizr.com/share/56937/documentation (once this PR is merged).

### Another list?! ಠ_ಠ

This list is derived from annotating the architecture model, so it **won’t be** another list that has to be maintained in isolation.

To show something in the list, annotate the C4 container with the `APIDocs` class:
(once we settle on a convention in GitHub repos, we may pull this information directly **from the repos**)

https://github.com/ministryofjustice/hmpps-architecture-as-code/blob/2a0425bf778f59af00bb1788cbde0b7cddebb34d/src/main/kotlin/model/HMPPSAuth.kt#L19-L26

### Can I see it?

It looks like this in my test workspace:
![image](https://user-images.githubusercontent.com/1526295/90621871-3aab2100-e20c-11ea-94b4-13950e4063d7.png)

### Where does it generate?

Documentation is generated to `{repo_root}/exports/docs` during the `defineWorkspace` call:
```
$ cat exports/docs/apidocs.md
## Published APIs

| Software System | API name | Purpose | Links |
| --- | --- | --- | --- |
| HMPPS Auth| API| OAuth2 server integrating with NOMIS data...<snip>
<snip>
```

## What is the intent behind these changes?

To make APIs in HMPPS easily discoverable (if they're in the model).