### PR TITLE
Add API docs to Delius and NOMIS containers

### DIFF
--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -44,6 +44,7 @@ class Delius private constructor() {
         "Community API",
         "API over the nDelius DB used by HMPPS Digital team applications and services", "Java"
       ).apply {
+        APIDocs("https://community-api.test.delius.probation.hmpps.dsd.io/swagger-ui.html").addTo(this)
         setUrl("https://github.com/ministryofjustice/community-api")
         uses(db, "connects to", "JDBC")
       }

--- a/src/main/kotlin/model/NOMIS.kt
+++ b/src/main/kotlin/model/NOMIS.kt
@@ -31,6 +31,7 @@ class NOMIS private constructor() {
         "API over the NOMIS DB used by Digital Prison team applications and services", "Java"
       ).apply {
         addProperty("previous-name", "Elite2 API")
+        APIDocs("https://api.prison.service.justice.gov.uk/swagger-ui.html").addTo(this)
         setUrl("https://github.com/ministryofjustice/prison-api")
         uses(db, "connects to", "JDBC")
       }

--- a/src/main/kotlin/model/NOMIS.kt
+++ b/src/main/kotlin/model/NOMIS.kt
@@ -57,6 +57,7 @@ class NOMIS private constructor() {
         "PrisonerSearch", "API over the NOMIS prisoner data held in Elasticsearch",
         "Kotlin"
       ).apply {
+        APIDocs("https://prisoner-offender-search.prison.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config").addTo(this)
         uses(elasticSearchStore, "Queries prisoner data from NOMIS Elasticsearch Index")
         setUrl("https://github.com/ministryofjustice/prisoner-offender-search")
         CloudPlatform.kubernetes.add(this)


### PR DESCRIPTION
## What does this pull request do?

Adds API docs to Delius `community-api` (related to https://github.com/ministryofjustice/community-api/pull/242)
Adds API docs to NOMIS `prisoner-offender-search` and `prison-api`s.

## What is the intent behind these changes?

To make sure we have as many APIs documented and published in #61 as possible.