### PR TITLE
Define key outputs from this architecture model

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Modelling architecture in HM Prisons and Probations Service (HMPPS) with the [C4
 
 ## Key outputs
 
+- Holistic representation of all software systems and [containers][c4-abstractions] (applications or data stores) within HMPPS Digital
 - Applications annotated with API documentation links are published to the [Published APIs](https://structurizr.com/workspace/56937/documentation#%2F:Published%20APIs) page
 - Interactive graph of model elements and their relationships:
   - [Explore the system interactions](https://structurizr.com/share/56937/explore/graph?softwareSystems=true&view=)
@@ -88,6 +89,5 @@ This command will locally generate all defined workspace diagrams without using 
 
 
 [c4]: https://c4model.com/
+[c4-abstractions]: https://c4model.com/#Abstractions
 [structurizr]: https://structurizr.com/
-[workspace-prison]: https://structurizr.com/share/55246
-[workspace-probation]: https://structurizr.com/share/54669

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
-# hmpps-architecture-as-code
-
 ![Publish](https://github.com/ministryofjustice/hmpps-architecture-as-code/workflows/Publish/badge.svg)
 ![Build and validate](https://github.com/ministryofjustice/hmpps-architecture-as-code/workflows/Build%20and%20validate/badge.svg)
 
+# hmpps-architecture-as-code
+
 Modelling architecture in HM Prisons and Probations Service (HMPPS) with the [C4 model][c4] and [Structurizr][structurizr].
+
+## Key outputs
+
+- Applications annotated with API documentation links are published to the [Published APIs](https://structurizr.com/workspace/56937/documentation#%2F:Published%20APIs) page
+- Interactive graph of model elements and their relationships:
+  - [Explore the system interactions](https://structurizr.com/share/56937/explore/graph?softwareSystems=true&view=)
+  - [Explore the container (application) interactions](https://structurizr.com/share/56937/explore/graph?containers=true&view=)
+  - [Explore how people use systems](https://structurizr.com/share/56937/explore/graph?people=true&softwareSystems=true&view=)
+- Views defined in the model are published to the [Diagrams](https://structurizr.com/share/56937/diagrams) page
+  - Published diagram images can be embedded in Confluence or GitHub readmes
+  - The diagrams will automatically update when they're next changed
+- Views defined in the model can be generated locally (see below)
 
 ## Workspaces
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Modelling architecture in HM Prisons and Probations Service (HMPPS) with the [C4
   - [Explore the container (application) interactions](https://structurizr.com/share/56937/explore/graph?containers=true&view=)
   - [Explore how people use systems](https://structurizr.com/share/56937/explore/graph?people=true&softwareSystems=true&view=)
 - Views defined in the model are published to the [Diagrams](https://structurizr.com/share/56937/diagrams) page
+  - For example, [overview of systems](https://structurizr.com/share/56937/images/system-overview.png) with [legend](https://structurizr.com/share/56937/images/system-overview-key.png)
   - Published diagram images can be embedded in Confluence or GitHub readmes
   - The diagrams will automatically update when they're next changed
 - Views defined in the model can be generated locally (see below)


### PR DESCRIPTION
## What does this pull request do?

Adds a "key outputs" section to the readme:

![image](https://user-images.githubusercontent.com/1526295/90882279-a247a480-e3a3-11ea-9290-72f858d68dc9.png)

https://github.com/ministryofjustice/hmpps-architecture-as-code/blob/4d51ab7cf4f167ab9d630b11260122b2bf4cf0dc/README.md#key-outputs

## What is the intent behind these changes?

I felt we were missing the articulation of what kinds of needs we were addressing with this repository.

This is a first attempt to define those.