### PR TITLE
Switch to manual layout for system overview

### DIFF
--- a/src/main/kotlin/defineViews.kt
+++ b/src/main/kotlin/defineViews.kt
@@ -8,7 +8,6 @@ import com.structurizr.view.ViewSet
 fun defineViews(model: Model, views: ViewSet) {
   views.createSystemLandscapeView("system-overview", "All systems").apply {
     addAllSoftwareSystems()
-    enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
   }
 
   // lifted from probation views

--- a/src/main/kotlin/defineViews.kt
+++ b/src/main/kotlin/defineViews.kt
@@ -8,6 +8,9 @@ import com.structurizr.view.ViewSet
 fun defineViews(model: Model, views: ViewSet) {
   views.createSystemLandscapeView("system-overview", "All systems").apply {
     addAllSoftwareSystems()
+
+    val noisySignOnSystems = listOf(HMPPSAuth.system, MoJSignOn.system)
+    noisySignOnSystems.forEach(::remove)
   }
 
   // lifted from probation views


### PR DESCRIPTION
## What does this pull request do?

It is possible to layout the diagrams by hand, given these conditions:

- The diagram key (here, `system-overview`) does not change
- The name of the elements do not change

When the workspace is pushed, Structurizr will attempt to retain the layout, even if the entire workspace is redefined (like we do).

This pull request disables automatic layout and removes the authentication systems as they had many relationships without adding much value.

### Trade-offs

- We will have to review the diagrams to see if the layout still makes sense.
- We will need people with editor permissions on Structurizr to layout the diagrams (and locking becomes an issue).

Are these reasonable?

### How does it look?

**Currently**
![system-overview-old](https://user-images.githubusercontent.com/1526295/90896813-31f94d00-e3bc-11ea-9bec-058d43ce73b9.png)

**After, arranging manually**

⚠️ *Note* the enterprise boundary box is manually arranged to look like this

![structurizr-55488-system-overview-boxed](https://user-images.githubusercontent.com/1526295/91181000-4d2bcb80-e6e0-11ea-814b-0dd434354e82.png)


## What is the intent behind these changes?

Related to #54; an experiment to create a layout in a way that's useful for us 😄 