### PR TITLE
Re-instate WMT in the list of systems

### DIFF
--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -43,7 +43,8 @@ fun defineWorkspace(): Workspace {
     ProbationCaseSampler,
     ProbationPractitioners,
     ProbationTeamsService,
-    Reporting
+    Reporting,
+    WMT
   )
   modelItems.forEach { it.defineModelEntities(workspace.model) }
 


### PR DESCRIPTION
## What does this pull request do?

Adds the "Workload Management Tool" back to the model. It's defined in code, but not added to the "list of model items" in `defineWorkspace()`.

In the future, it would be great if all these model items could appear without manual maintenance, but no effort is made here to resolve that.

## What is the intent behind these changes?

😱 I forgot to add it to the list earlier in 7d8346a23b44099e58d441756a02645bdcdc1e5f.