### PR TITLE
Remove authentication systems from the overview diagram

### DIFF
--- a/src/main/kotlin/defineViews.kt
+++ b/src/main/kotlin/defineViews.kt
@@ -8,6 +8,10 @@ import com.structurizr.view.ViewSet
 fun defineViews(model: Model, views: ViewSet) {
   views.createSystemLandscapeView("system-overview", "All systems").apply {
     addAllSoftwareSystems()
+
+    val noisySignOnSystems = listOf(HMPPSAuth.system, MoJSignOn.system)
+    noisySignOnSystems.forEach(::remove)
+
     enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
   }
 


### PR DESCRIPTION
## What does this pull request do?

Removes authentication systems with many connections from the system overview; that diagram is mainly for showing how everything interactions and in that case, sign-on capabilities are not significant.

Following discussions in #65.

| Before | After |
| --- | --- |
| ![system-overview-before](https://user-images.githubusercontent.com/1526295/91319701-94838c00-e7b4-11ea-9d3a-0d7d69252927.png) | ![system-overview-after](https://user-images.githubusercontent.com/1526295/91319704-951c2280-e7b4-11ea-9f9d-6def53392f36.png) |

## What is the intent behind these changes?

These systems have _many_ connections, and they provide any significant detail in the overview diagram. If we remove them, it simplifies the view.