### PR TITLE
Make HMPPS 'enterprise' boundary consistent

### DIFF
--- a/src/main/kotlin/OutsideHMPPS.kt
+++ b/src/main/kotlin/OutsideHMPPS.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Element
+import com.structurizr.model.Location
+import com.structurizr.model.Person
+import com.structurizr.model.SoftwareSystem
+
+class OutsideHMPPS {
+  companion object : addTo {
+    override fun addTo(element: Element) {
+      when (element) {
+        is SoftwareSystem -> element.setLocation(Location.External)
+        is Person -> element.setLocation(Location.External)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/ProblemArea.kt
+++ b/src/main/kotlin/ProblemArea.kt
@@ -2,10 +2,10 @@ package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Element
 
-enum class ProblemArea() {
+enum class ProblemArea : addTo {
   GETTING_THE_RIGHT_REHABILITATION;
 
-  fun addTo(element: Element) {
+  override fun addTo(element: Element) {
     element.addProperty("problem-area", this.toString())
   }
 

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -2,11 +2,20 @@ package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Element
 
-enum class Tags() {
-  DATABASE, WEB_BROWSER, PROVIDER, DEPRECATED, SOFTWARE_AS_A_SERVICE;
+enum class Tags : addTo {
+  DATABASE,
+  WEB_BROWSER,
+  PROVIDER {
+    override fun addTo(element: Element) {
+      super.addTo(element)
+      OutsideHMPPS.addTo(element)
+    }
+  },
+  DEPRECATED,
+  SOFTWARE_AS_A_SERVICE;
 
   // Usage example: Tags.DATABASE.addTo(any_model_element)
-  fun addTo(element: Element) {
+  override fun addTo(element: Element) {
     element.addTags(this.toString())
   }
 }

--- a/src/main/kotlin/addTo.kt
+++ b/src/main/kotlin/addTo.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Element
+
+interface addTo {
+  fun addTo(element: Element)
+}

--- a/src/main/kotlin/defineGlobalViews.kt
+++ b/src/main/kotlin/defineGlobalViews.kt
@@ -28,7 +28,6 @@ fun defineGlobalViews(model: Model, views: ViewSet) {
       .filterNot { ProblemArea.GETTING_THE_RIGHT_REHABILITATION.isOn(it) }
     otherSystems.forEach { remove(it) }
 
-    setEnterpriseBoundaryVisible(false)
     enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 400, 400)
   }
 
@@ -50,14 +49,15 @@ fun defineGlobalViews(model: Model, views: ViewSet) {
   }
 
   views.createSystemContextView(
-    pathfinder, "PathfinderSystemContext", "The system context diagram for the Pathfinder System."
+    pathfinder,
+    "PathfinderSystemContext",
+    "The system context diagram for the Pathfinder System."
   ).apply {
     addDefaultElements()
     add(NOMIS.system)
     add(Delius.system)
     add(HMPPSAuth.system)
     enableAutomaticLayout()
-    isEnterpriseBoundaryVisible = false
   }
 
   views.createDeploymentView(pathfinder, "PathfinderProductionDeployment", "The Production deployment scenario for the Pathfinder service").apply {

--- a/src/main/kotlin/defineGlobalViews.kt
+++ b/src/main/kotlin/defineGlobalViews.kt
@@ -5,7 +5,7 @@ import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
 
-fun defineViews(model: Model, views: ViewSet) {
+fun defineGlobalViews(model: Model, views: ViewSet) {
   views.createSystemLandscapeView("system-overview", "All systems").apply {
     addAllSoftwareSystems()
 

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -3,6 +3,59 @@ package uk.gov.justice.hmpps.architecture
 import com.structurizr.Workspace
 import com.structurizr.model.CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy
 import com.structurizr.model.Enterprise
+import com.structurizr.model.Model
+import com.structurizr.view.ViewSet
+
+private val ModelItems = listOf(
+  CaseNotesToProbation,
+  CourtUsers,
+  CRCSystem,
+  Delius,
+  EPF,
+  EQuiP,
+  HMPPSAuth,
+  IM,
+  InterventionTeams,
+  Licences,
+  MoJSignOn,
+  NationalPrisonRadio,
+  NDH,
+  NID,
+  NOMIS,
+  OASys,
+  OffenderManagementInCustody,
+  PrepareCaseForCourt,
+  PrisonerContentHub,
+  PrisonToProbationUpdate,
+  PrisonVisitsBooking,
+  ProbationCaseSampler,
+  ProbationPractitioners,
+  ProbationTeamsService,
+  Reporting,
+  WMT
+)
+
+private fun defineModelItems(model: Model) {
+  model.setImpliedRelationshipsStrategy(
+    CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy()
+  )
+
+  AWS.defineDeploymentNodes(model)
+  CloudPlatform.defineDeploymentNodes(model)
+  Heroku.defineDeploymentNodes(model)
+
+  ModelItems.forEach { it.defineModelEntities(model) }
+  defineModelWithDeprecatedSyntax(model)
+}
+
+private fun defineRelationships() {
+  ModelItems.forEach { it.defineRelationships() }
+}
+
+private fun defineViews(model: Model, views: ViewSet) {
+  ModelItems.forEach { it.defineViews(views) }
+  defineGlobalViews(model, views)
+}
 
 fun defineWorkspace(): Workspace {
   val enterprise = Enterprise("HM Prison and Probation Service")
@@ -10,51 +63,10 @@ fun defineWorkspace(): Workspace {
   workspace.id = 56937
   workspace.model.enterprise = enterprise
 
-  workspace.model.setImpliedRelationshipsStrategy(
-    CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy()
-  )
-
-  AWS.defineDeploymentNodes(workspace.model)
-  CloudPlatform.defineDeploymentNodes(workspace.model)
-  Heroku.defineDeploymentNodes(workspace.model)
-
-  val modelItems = listOf(
-    CaseNotesToProbation,
-    CourtUsers,
-    CRCSystem,
-    Delius,
-    EPF,
-    EQuiP,
-    HMPPSAuth,
-    IM,
-    InterventionTeams,
-    Licences,
-    MoJSignOn,
-    NationalPrisonRadio,
-    NDH,
-    NID,
-    NOMIS,
-    OASys,
-    OffenderManagementInCustody,
-    PrepareCaseForCourt,
-    PrisonerContentHub,
-    PrisonToProbationUpdate,
-    PrisonVisitsBooking,
-    ProbationCaseSampler,
-    ProbationPractitioners,
-    ProbationTeamsService,
-    Reporting,
-    WMT
-  )
-  modelItems.forEach { it.defineModelEntities(workspace.model) }
-
-  defineModelWithDeprecatedSyntax(workspace.model)
-  modelItems.forEach { it.defineRelationships() }
-  modelItems.forEach { it.defineViews(workspace.views) }
-
+  defineModelItems(workspace.model)
+  defineRelationships()
   defineViews(workspace.model, workspace.views)
   defineStyles(workspace.views.configuration.styles)
-
   defineDocumentation(workspace)
 
   return workspace

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -7,7 +7,7 @@ import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.view.ViewSet
 
-private val ModelItems = listOf(
+private val MODEL_ITEMS = listOf(
   CaseNotesToProbation,
   CourtUsers,
   CRCSystem,
@@ -45,7 +45,7 @@ private fun defineModelItems(model: Model) {
   CloudPlatform.defineDeploymentNodes(model)
   Heroku.defineDeploymentNodes(model)
 
-  ModelItems.forEach { it.defineModelEntities(model) }
+  MODEL_ITEMS.forEach { it.defineModelEntities(model) }
   defineModelWithDeprecatedSyntax(model)
 }
 
@@ -57,11 +57,11 @@ private fun changeUndefinedLocationsToInternal(model: Model) {
 }
 
 private fun defineRelationships() {
-  ModelItems.forEach { it.defineRelationships() }
+  MODEL_ITEMS.forEach { it.defineRelationships() }
 }
 
 private fun defineViews(model: Model, views: ViewSet) {
-  ModelItems.forEach { it.defineViews(views) }
+  MODEL_ITEMS.forEach { it.defineViews(views) }
   defineGlobalViews(model, views)
 }
 

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.hmpps.architecture
 import com.structurizr.Workspace
 import com.structurizr.model.CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy
 import com.structurizr.model.Enterprise
+import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.view.ViewSet
 
@@ -48,6 +49,13 @@ private fun defineModelItems(model: Model) {
   defineModelWithDeprecatedSyntax(model)
 }
 
+private fun changeUndefinedLocationsToInternal(model: Model) {
+  model.softwareSystems
+    .filter { it.location == Location.Unspecified }.forEach { it.setLocation(Location.Internal) }
+  model.people
+    .filter { it.location == Location.Unspecified }.forEach { it.setLocation(Location.Internal) }
+}
+
 private fun defineRelationships() {
   ModelItems.forEach { it.defineRelationships() }
 }
@@ -64,6 +72,8 @@ fun defineWorkspace(): Workspace {
   workspace.model.enterprise = enterprise
 
   defineModelItems(workspace.model)
+  changeUndefinedLocationsToInternal(workspace.model)
+
   defineRelationships()
   defineViews(workspace.model, workspace.views)
   defineStyles(workspace.views.configuration.styles)

--- a/src/main/kotlin/model/HMPPSAuth.kt
+++ b/src/main/kotlin/model/HMPPSAuth.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Container
-import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
@@ -12,9 +11,7 @@ class HMPPSAuth private constructor() {
     lateinit var app: Container
 
     override fun defineModelEntities(model: Model) {
-      system = model.addSoftwareSystem("HMPPS Auth", "Allows users to login into digital services").apply {
-        setLocation(Location.Internal)
-      }
+      system = model.addSoftwareSystem("HMPPS Auth", "Allows users to login into digital services")
 
       app = system.addContainer(
         "API",

--- a/src/main/kotlin/model/NOMIS.kt
+++ b/src/main/kotlin/model/NOMIS.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Container
-import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
@@ -18,9 +17,7 @@ class NOMIS private constructor() {
       system = model.addSoftwareSystem(
         "NOMIS",
         "National Offender Management Information System,\nthe case management system for offender data in use in custody - both public and private prisons"
-      ).apply {
-        setLocation(Location.Internal)
-      }
+      )
 
       db = system.addContainer("NOMIS database", null, "Oracle").apply {
         Tags.DATABASE.addTo(this)

--- a/src/main/kotlin/model/NationalPrisonRadio.kt
+++ b/src/main/kotlin/model/NationalPrisonRadio.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.hmpps.architecture
 
-import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
@@ -15,7 +14,6 @@ class NationalPrisonRadio private constructor() {
         "The national radio station for prisoners. Made by prisoners, for prisoners"
       ).apply {
         Tags.PROVIDER.addTo(this)
-        setLocation(Location.External)
       }
     }
 

--- a/src/main/kotlin/model/OffenderManagementInCustody.kt
+++ b/src/main/kotlin/model/OffenderManagementInCustody.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Container
-import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
@@ -17,13 +16,9 @@ class OffenderManagementInCustody private constructor() {
       system = model.addSoftwareSystem(
         "Offender Management in Custody",
         "A service for handling the handover of service users from prison to probation"
-      ).apply {
-        setLocation(Location.Internal)
-      }
+      )
 
-      ldu = model.addPerson("Local Divisional Unit").apply {
-        setLocation(Location.Internal)
-      }
+      ldu = model.addPerson("Local Divisional Unit")
 
       allocationManager = system.addContainer("Offender Management Allocation Manager", "A service for allocating Prisoners to Prisoner Offender Managers (POMs)", "Ruby on Rails").apply {
         setUrl("https://github.com/ministryofjustice/offender-management-allocation-manager")

--- a/src/main/kotlin/model/PrepareCaseForCourt.kt
+++ b/src/main/kotlin/model/PrepareCaseForCourt.kt
@@ -15,12 +15,12 @@ class PrepareCaseForCourt private constructor() {
     lateinit var courtCaseMatcher: Container
 
     override fun defineModelEntities(model: Model) {
-
-      system = model.addSoftwareSystem("Prepare a Case for Court", "Digital Service for Probation Officers working in magistrates' courts, " +
-        "providing them with a single location to access the defendant information they need to provide sound and timely sentencing guidance to magistrates")
-        .apply {
-          setLocation(Location.Internal)
-        }
+      system = model.addSoftwareSystem(
+        "Prepare a Case for Court",
+        "Digital Service for Probation Officers working in magistrates' courts, " +
+          "providing them with a single location to access the defendant information " +
+          "they need to provide sound and timely sentencing guidance to magistrates"
+      )
 
       val casesDb = system.addContainer(
         "Cases Database",

--- a/src/main/kotlin/model/PrisonerContentHub.kt
+++ b/src/main/kotlin/model/PrisonerContentHub.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Container
-import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
@@ -28,7 +27,6 @@ class PrisonerContentHub private constructor() {
         The Prisoner Content Hub is a platform for prisoners to access data, content and services supporting individual progression and freeing up staff time.
         """.trimIndent()
       ).apply {
-        setLocation(Location.Internal)
         val PRISON_PROBATION_PROPERTY_NAME = "business_unit"
         val PRISON_SERVICE = "prisons"
         addProperty(PRISON_PROBATION_PROPERTY_NAME, PRISON_SERVICE)
@@ -82,29 +80,26 @@ class PrisonerContentHub private constructor() {
         **/
       model.addPerson("Feedback Reporter", "HMPPS Staff collating feedback for protection, product development and analytics").apply {
         uses(kibanaDashboard, "Extracts CSV files of prisoner feedback, views individual feedback responses, and analyses sentiment and statistics of feedback")
-        setLocation(Location.Internal)
       }
 
       model.addPerson("Prisoner", "A prisoner over 18 years old, held in the public prison estate").apply {
         uses(contentHubFrontend, "Views videos, audio programmes, site updates, and rehabilitative material")
         uses(frontendProxy, "Listens to National Prison Radio live stream")
-        setLocation(Location.External)
+        OutsideHMPPS.addTo(this)
       }
 
       model.addPerson("Young Offender", "A person under 18, held in a Young Offender Institute").apply {
         uses(contentHubFrontend, "Views videos, audio programmes, site updates, and rehabilitative material")
         uses(frontendProxy, "Listens to National Prison Radio live stream")
-        setLocation(Location.External)
+        OutsideHMPPS.addTo(this)
       }
 
       model.addPerson("Content editor", "HMPPS Digital staff curating content for the entire prison estate and supporting individual prisons").apply {
         uses(drupal, "Authors and curates content for the prison estate")
-        setLocation(Location.Internal)
       }
 
       model.addPerson("Prison Content editor", "A content author on-site in a prison, authoring content for their prison").apply {
         uses(drupal, "Authors and curates content for their prison")
-        setLocation(Location.Internal)
       }
     }
 


### PR DESCRIPTION
## What does this pull request do?

Adds an abstraction called `OutsideHMPPS` which can be used to mark systems or people. This makes it easier to define what's included in HMPPS and what isn't.

This abstraction also automatically applies to `Tags.PROVIDER`, which reduces the burden of having to remember to also mark providers as external entities.

Anything that is defined in the model __but__ not marked as "outside" is automatically converted to "inside".

🙏 Please review commit-by-commit.

💠 The main benefit is the consistency of diagrams (assuming #67 will be merged).

| Before | After |
| --- | --- |
| ![system-overview-before](https://user-images.githubusercontent.com/1526295/91323063-5c7e4800-e7b8-11ea-865f-4964cdcce21b.png) | ![system-overview-after](https://user-images.githubusercontent.com/1526295/91323066-5e480b80-e7b8-11ea-8547-b18acfed8e94.png) |


## What is the intent behind these changes?

To remove the manual overhead of having to mark all HMPPS systems and people with `this.setLocation(Location.Internal)`.

Instead, we now mark everything _outside_ HMPPS with `OutsideHMPPS.addTo(this)`.

This shifts the language from _how_ we achieve the result to _what_ we want to describe.

#65 also mentions a need to "fix" the enterprise boundaries.