### PR TITLE
Mark HMCTS system as "outside" instead of "provider"

### DIFF
--- a/src/main/kotlin/model/PrepareCaseForCourt.kt
+++ b/src/main/kotlin/model/PrepareCaseForCourt.kt
@@ -81,7 +81,7 @@ class PrepareCaseForCourt private constructor() {
       model.addSoftwareSystem("HMCTS Crime Portal", "Case Management for HMCTS holding data relating to court cases")
         .apply {
           setLocation(Location.External)
-          Tags.PROVIDER.addTo(this)
+          OutsideHMPPS.addTo(this)
           uses(crimePortalMirrorGateway, "Sends court lists to")
         }
     }


### PR DESCRIPTION
## What does this pull request do?

Changes _HMCTS Crime Portal_ to be categorised as a system outside HMPPS, but not as a system which is provided by 3rd parties. Now that #68 introduced `OutsideHMPPS`, we can now make this distinction.

I feel the nature of a government-provided service is better captured this way. For me green means "contracted private companies". What do you think, @markberridge?

### How does it look?

On the rendered diagrams, this will make the system blueish rather than green.

| Before | After |
| --- | --- |
| ![prepare-case-context-old](https://user-images.githubusercontent.com/1526295/91439341-b2102e80-e864-11ea-98e7-debbd8851c10.png) | ![structurizr-55488-prepare-case-context-new](https://user-images.githubusercontent.com/1526295/91439346-b3d9f200-e864-11ea-906d-8678ce84e2f5.png) |

## What is the intent behind these changes?

The HM Courts and Tribunals is a government organisation. It feels more applicable that they appear "outside" HMPPS but not as a contracted provider of services.