### PR TITLE
Move "annotations" to their own package

### DIFF
--- a/src/main/kotlin/annotations/APIDocs.kt
+++ b/src/main/kotlin/annotations/APIDocs.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.hmpps.architecture
+package uk.gov.justice.hmpps.architecture.annotations
 
 import com.structurizr.model.Element
 

--- a/src/main/kotlin/annotations/OutsideHMPPS.kt
+++ b/src/main/kotlin/annotations/OutsideHMPPS.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.hmpps.architecture
+package uk.gov.justice.hmpps.architecture.annotations
 
 import com.structurizr.model.Element
 import com.structurizr.model.Location

--- a/src/main/kotlin/annotations/ProblemArea.kt
+++ b/src/main/kotlin/annotations/ProblemArea.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.hmpps.architecture
+package uk.gov.justice.hmpps.architecture.annotations
 
 import com.structurizr.model.Element
 

--- a/src/main/kotlin/annotations/Tags.kt
+++ b/src/main/kotlin/annotations/Tags.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.hmpps.architecture
+package uk.gov.justice.hmpps.architecture.annotations
 
 import com.structurizr.model.Element
 

--- a/src/main/kotlin/annotations/addTo.kt
+++ b/src/main/kotlin/annotations/addTo.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.hmpps.architecture
+package uk.gov.justice.hmpps.architecture.annotations
 
 import com.structurizr.model.Element
 

--- a/src/main/kotlin/defineGlobalViews.kt
+++ b/src/main/kotlin/defineGlobalViews.kt
@@ -4,6 +4,7 @@ import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
 
 fun defineGlobalViews(model: Model, views: ViewSet) {
   views.createSystemLandscapeView("system-overview", "All systems").apply {

--- a/src/main/kotlin/defineStyles.kt
+++ b/src/main/kotlin/defineStyles.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.view.Shape
 import com.structurizr.view.Styles
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 fun defineStyles(styles: Styles) {
   styles.addElementStyle("Software System").background("#aabbdd")

--- a/src/main/kotlin/model/CRCSystem.kt
+++ b/src/main/kotlin/model/CRCSystem.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.hmpps.architecture
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class CRCSystem private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -6,6 +6,9 @@ import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.APIDocs
+import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class Delius private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/EPF.kt
+++ b/src/main/kotlin/model/EPF.kt
@@ -5,6 +5,7 @@ import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
 
 class EPF private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/EQuiP.kt
+++ b/src/main/kotlin/model/EQuiP.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.hmpps.architecture
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
 
 class EQuiP private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/HMPPSAuth.kt
+++ b/src/main/kotlin/model/HMPPSAuth.kt
@@ -4,6 +4,8 @@ import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.APIDocs
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class HMPPSAuth private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/IM.kt
+++ b/src/main/kotlin/model/IM.kt
@@ -5,6 +5,8 @@ import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class IM private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/InterventionTeams.kt
+++ b/src/main/kotlin/model/InterventionTeams.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.hmpps.architecture
 import com.structurizr.model.Model
 import com.structurizr.model.Person
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class InterventionTeams private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/MoJSignOn.kt
+++ b/src/main/kotlin/model/MoJSignOn.kt
@@ -4,6 +4,7 @@ import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class MoJSignOn private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/NID.kt
+++ b/src/main/kotlin/model/NID.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.hmpps.architecture
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class NID private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/NOMIS.kt
+++ b/src/main/kotlin/model/NOMIS.kt
@@ -4,6 +4,8 @@ import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.APIDocs
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class NOMIS private constructor() {
 

--- a/src/main/kotlin/model/NationalPrisonRadio.kt
+++ b/src/main/kotlin/model/NationalPrisonRadio.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.hmpps.architecture
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class NationalPrisonRadio private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/OASys.kt
+++ b/src/main/kotlin/model/OASys.kt
@@ -4,6 +4,7 @@ import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.APIDocs
 
 class OASys private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/Pathfinder.kt
+++ b/src/main/kotlin/model/Pathfinder.kt
@@ -4,6 +4,7 @@ package uk.gov.justice.hmpps.architecture
 import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class Pathfinder(model: Model) {
   val system: SoftwareSystem

--- a/src/main/kotlin/model/PrepareCaseForCourt.kt
+++ b/src/main/kotlin/model/PrepareCaseForCourt.kt
@@ -6,6 +6,8 @@ import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.OutsideHMPPS
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class PrepareCaseForCourt private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/PrisonVisitsBooking.kt
+++ b/src/main/kotlin/model/PrisonVisitsBooking.kt
@@ -5,6 +5,7 @@ import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class PrisonVisitsBooking private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/PrisonerContentHub.kt
+++ b/src/main/kotlin/model/PrisonerContentHub.kt
@@ -5,6 +5,8 @@ import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.OutsideHMPPS
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class PrisonerContentHub private constructor() {
 

--- a/src/main/kotlin/model/ProbationPractitioners.kt
+++ b/src/main/kotlin/model/ProbationPractitioners.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.hmpps.architecture
 import com.structurizr.model.Model
 import com.structurizr.model.Person
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class ProbationPractitioners private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/ProbationTeamsService.kt
+++ b/src/main/kotlin/model/ProbationTeamsService.kt
@@ -6,6 +6,8 @@ import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.APIDocs
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class ProbationTeamsService private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/Reporting.kt
+++ b/src/main/kotlin/model/Reporting.kt
@@ -5,6 +5,8 @@ import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
+import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class Reporting private constructor() {
   companion object : HMPPSSoftwareSystem {


### PR DESCRIPTION
## What does this pull request do?

Moves all constructs responsible for "annotating" a model object to a separate package so they can be viewed in a single place as a "library".

<img width="367" alt="image" src="https://user-images.githubusercontent.com/1526295/92219079-f7021980-ee91-11ea-8433-97c4d35bcb19.png">


## What is the intent behind these changes?

I was wondering (in the context of https://github.com/ministryofjustice/laa-architecture-as-code) if I were new to the repository, would I know what "annotations" were available to use with the model? Are they discoverable?

These questions led to moving these to a single package; the next step would be documentation about their expected effects.