### PR TITLE
Swap OASys name and expanded acronym

### DIFF
--- a/src/main/kotlin/model/OASys.kt
+++ b/src/main/kotlin/model/OASys.kt
@@ -12,7 +12,7 @@ class OASys private constructor() {
     lateinit var assessmentsApi: Container
 
     override fun defineModelEntities(model: Model) {
-      system = model.addSoftwareSystem("Offender Assessment System", "(OASys) Assesses the risks and needs of offenders").apply {
+      system = model.addSoftwareSystem("OASys", "(Offender Assessment System) Assesses the risks and needs of offenders").apply {
         setUrl("https://dsdmoj.atlassian.net/wiki/spaces/~474366104/pages/2046820357/OASys+Overview")
       }
 


### PR DESCRIPTION
## What does this pull request 

Makes "OASys" more visible on diagrams by using its abbreviation instead of its full name.

## What is the intent behind these changes?

On diagrams, I was automatically looking for "OASys" -- the term is embedded into our vocabulary now, so (I feel) it's better to see it on the title right away.