### PR TITLE
Update NDH relationships

### DIFF
--- a/src/main/kotlin/defineGlobalViews.kt
+++ b/src/main/kotlin/defineGlobalViews.kt
@@ -11,7 +11,9 @@ fun defineGlobalViews(model: Model, views: ViewSet) {
     addAllSoftwareSystems()
 
     val noisySignOnSystems = listOf(HMPPSAuth.system, MoJSignOn.system)
+    val noisyHubSystems = listOf(NDH.system)
     noisySignOnSystems.forEach(::remove)
+    noisyHubSystems.forEach(::remove)
 
     enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
   }

--- a/src/main/kotlin/model/CaseNotesToProbation.kt
+++ b/src/main/kotlin/model/CaseNotesToProbation.kt
@@ -7,7 +7,6 @@ import com.structurizr.view.ViewSet
 class CaseNotesToProbation private constructor() {
   companion object : HMPPSSoftwareSystem {
     lateinit var system: SoftwareSystem
-    lateinit var ndh: SoftwareSystem
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(

--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -75,7 +75,6 @@ class Delius private constructor() {
       CourtUsers.courtAdministrator.uses(system, "records CAS decision, referrals in")
 
       system.uses(IM.system, "pushes active sentence requirements or licence conditions to", "IAPS")
-      system.uses(OASys.system, "offender details, offence details, sentence info are copied into", "NDH")
 
       InterventionTeams.interventionServicesTeam.interactsWith(supportTeam, "raises task to create or update an accredited programme with")
       InterventionTeams.crcProgrammeManager.interactsWith(supportTeam, "raises task to update interventions with")

--- a/src/main/kotlin/model/NDH.kt
+++ b/src/main/kotlin/model/NDH.kt
@@ -45,6 +45,24 @@ class NDH private constructor() {
     }
 
     override fun defineRelationships() {
+      defineImpliedRelationships()
+      defineDirectRelationships()
+    }
+
+    override fun defineViews(views: ViewSet) {
+    }
+
+    fun defineImpliedRelationships() {
+      // these are the flows what NDH enables
+      // it's very useful to see these relationships between NOMIS, OASys and Delius
+      // without having to track it through a 'hub'
+      NOMIS.system.uses(OASys.system, "offender details are copied into", "NDH")
+      OASys.system.uses(NOMIS.system, "offender details are looked up from", "NDH")
+      OASys.system.uses(Delius.system, "offender risk assessment and specific risk data are copied into", "NDH")
+      OASys.system.uses(Delius.system, "offender details are looked up from", "NDH")
+    }
+
+    fun defineDirectRelationships() {
       system.uses(NOMIS.custodyApi, "periodically polls the NOMIS Events table to look for changes to offender data via")
       system.uses(OASys.system, "sends changed offender data collected from NOMIS via", "SOAP/XML")
 
@@ -60,9 +78,6 @@ class NDH private constructor() {
 
       OASys.system.uses(offenderRiskUpdates, "used during certain points in the assessment process to receive specific risk data from")
       offenderRiskUpdates.uses(Delius.system, "sends specific risk data to", "SOAP/XML/ActiveMQ")
-    }
-
-    override fun defineViews(views: ViewSet) {
     }
   }
 }

--- a/src/main/kotlin/model/NOMIS.kt
+++ b/src/main/kotlin/model/NOMIS.kt
@@ -13,6 +13,7 @@ class NOMIS private constructor() {
     lateinit var system: SoftwareSystem
     lateinit var db: Container
     lateinit var offenderSearch: Container
+    lateinit var custodyApi: Container
     lateinit var prisonApi: Container
 
     override fun defineModelEntities(model: Model) {
@@ -23,6 +24,16 @@ class NOMIS private constructor() {
 
       db = system.addContainer("NOMIS database", null, "Oracle").apply {
         Tags.DATABASE.addTo(this)
+      }
+
+      custodyApi = system.addContainer(
+        "Custody API (Deprecated)",
+        "Provided REST access to the Nomis Oracle DB offender information - deprecated; use prison-api instead",
+        "Java"
+      ).apply {
+        setUrl("https://github.com/ministryofjustice/custody-api")
+        Tags.DEPRECATED.addTo(this)
+        uses(db, "connects to", "JDBC")
       }
 
       prisonApi = system.addContainer(
@@ -75,7 +86,6 @@ class NOMIS private constructor() {
     }
 
     override fun defineRelationships() {
-      system.uses(Delius.system, "offender data is copied into", "NDH")
       system.uses(PrisonToProbationUpdate.system, "notifies changes")
     }
 

--- a/src/main/kotlin/model/OASys.kt
+++ b/src/main/kotlin/model/OASys.kt
@@ -30,7 +30,6 @@ class OASys private constructor() {
     }
 
     override fun defineRelationships() {
-      system.uses(Delius.system, "assessment info, risk measures are copied into", "NDH")
       ProbationPractitioners.nps.uses(system, "records offender risk (attendance, contact, etc.) and assessment in")
       ProbationPractitioners.crc.uses(system, "records offender risk (attendance, contact, etc.) and assessment in")
     }


### PR DESCRIPTION
## What does this pull request do?

I stumbled across the [NDH Replacement][page] wiki page and it describes NDH in detail.

This change reflects the content on the wiki.

## Anything else worth mentioning?

fe71e72339d449733acf2315bbab2c8265d9f85c explicitly declares the relationships between software systems that are _enabled_ by NDH:

> NDH has the characteristics of a 'hub'-like system. It either pulls from or pushes to OASys, nDelius and NOMIS.
>
> These relationships make sense, however, if we want to have high-level view, this communication pattern creates noise.
>
> If we assume NDH to be a "protocol" instead of "system" for the purposes of high-level views, we can map out the relationships enabled by the system (`defineImpliedRelationships()`).
>
> For more detailed views, we can keep the implementation details.

It sounded sensible to call it out explicitly in `NDH::defineImpliedRelationships`, instead of scattering the "implied" relationships around in the systems involved, but this isn't a strongly held view. What do you think?

Although, to be fair, looking at the relationships it sounds like NDH is a subsystem for OASys - nearly all interactions are kicked off by OASys.

## What is the intent behind these changes?

To keep systems up-to-date :)


[page]: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/2339766596/NDH+Replacement