### PR TITLE
Add "offender management in custody" container view

### DIFF
--- a/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
+++ b/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
@@ -10,7 +10,7 @@ fun defineModelWithDeprecatedSyntax(model: Model) {
 
   Pathfinder(model)
 
-  spo.uses(OffenderManagementInCustody.allocationManager, "look at unallocated service users coming from court in")
+  spo.uses(OffenderManagementInCustody.allocationManager, "overview staff allocations in")
   pom.uses(OffenderManagementInCustody.allocationManager, "look at service users who need handing over to community in")
 
   // lifted from probation model

--- a/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
+++ b/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
@@ -22,5 +22,4 @@ fun defineModelWithDeprecatedSyntax(model: Model) {
   Reporting.ndmis.uses(OffenderManagementInCustody.allocationManager, "sends extracts containing service user allocation to", "email")
 
   hmip.uses(Reporting.ndmis, "uses data from")
-  OffenderManagementInCustody.ldu.uses(Delius.system, "maintains 'shadow' team assignments for service users during prison-to-probation handover in")
 }

--- a/src/main/kotlin/model/OffenderManagementInCustody.kt
+++ b/src/main/kotlin/model/OffenderManagementInCustody.kt
@@ -27,6 +27,7 @@ class OffenderManagementInCustody private constructor() {
 
     override fun defineRelationships() {
       ldu.uses(allocationManager, "gets notification about ??? from", "gov.uk notify")
+      ldu.uses(Delius.system, "maintains 'shadow' team assignments for service users during prison-to-probation handover in")
       allocationManager.uses(NOMIS.prisonApi, "polls service users currently in the logged in user's prison from")
     }
 

--- a/src/main/kotlin/model/OffenderManagementInCustody.kt
+++ b/src/main/kotlin/model/OffenderManagementInCustody.kt
@@ -19,7 +19,11 @@ class OffenderManagementInCustody private constructor() {
         "A service for handling the handover of service users from prison to probation"
       )
 
-      ldu = model.addPerson("Local Delivery Unit")
+      ldu = model.addPerson(
+        "Local Delivery Unit",
+        "An operational unit comprising an office or offices, " +
+          "generally coterminous with police basic command units and local authority structures"
+      )
 
       allocationManager = system.addContainer("Offender Management Allocation Manager", "A service for allocating Prisoners to Prisoner Offender Managers (POMs)", "Ruby on Rails").apply {
         setUrl("https://github.com/ministryofjustice/offender-management-allocation-manager")

--- a/src/main/kotlin/model/OffenderManagementInCustody.kt
+++ b/src/main/kotlin/model/OffenderManagementInCustody.kt
@@ -40,6 +40,8 @@ class OffenderManagementInCustody private constructor() {
         addDefaultElements()
         add(Delius.system)
         add(NOMIS.prisonApi)
+        add(NOMIS.db)
+        HMPPSAuth.system.getEfferentRelationshipsWith(Delius.system).forEach(::remove)
 
         setExternalSoftwareSystemBoundariesVisible(true)
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/OffenderManagementInCustody.kt
+++ b/src/main/kotlin/model/OffenderManagementInCustody.kt
@@ -18,7 +18,7 @@ class OffenderManagementInCustody private constructor() {
         "A service for handling the handover of service users from prison to probation"
       )
 
-      ldu = model.addPerson("Local Divisional Unit")
+      ldu = model.addPerson("Local Delivery Unit")
 
       allocationManager = system.addContainer("Offender Management Allocation Manager", "A service for allocating Prisoners to Prisoner Offender Managers (POMs)", "Ruby on Rails").apply {
         setUrl("https://github.com/ministryofjustice/offender-management-allocation-manager")
@@ -26,7 +26,7 @@ class OffenderManagementInCustody private constructor() {
     }
 
     override fun defineRelationships() {
-      ldu.uses(allocationManager, "gets notification about ??? from", "gov.uk notify")
+      ldu.uses(allocationManager, "notified about community allocation requests from", "gov.uk notify")
       ldu.uses(Delius.system, "maintains 'shadow' team assignments for service users during prison-to-probation handover in")
       allocationManager.uses(NOMIS.prisonApi, "polls service users currently in the logged in user's prison from")
     }

--- a/src/main/kotlin/model/OffenderManagementInCustody.kt
+++ b/src/main/kotlin/model/OffenderManagementInCustody.kt
@@ -41,9 +41,9 @@ class OffenderManagementInCustody private constructor() {
 
     override fun defineViews(views: ViewSet) {
       views.createContainerView(system, "omic-container", null).apply {
-        addDefaultElements()
-        add(Delius.system)
-        add(NOMIS.prisonApi)
+        listOf(ldu, allocationManager).forEach(::addNearestNeighbours)
+        remove(system)
+
         add(NOMIS.db)
         HMPPSAuth.system.getEfferentRelationshipsWith(Delius.system).forEach(::remove)
 

--- a/src/main/kotlin/model/OffenderManagementInCustody.kt
+++ b/src/main/kotlin/model/OffenderManagementInCustody.kt
@@ -4,6 +4,7 @@ import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
 
 class OffenderManagementInCustody private constructor() {
@@ -41,7 +42,7 @@ class OffenderManagementInCustody private constructor() {
         add(NOMIS.prisonApi)
 
         setExternalSoftwareSystemBoundariesVisible(true)
-        enableAutomaticLayout()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
       }
     }
   }

--- a/src/main/kotlin/model/OffenderManagementInCustody.kt
+++ b/src/main/kotlin/model/OffenderManagementInCustody.kt
@@ -31,6 +31,14 @@ class OffenderManagementInCustody private constructor() {
     }
 
     override fun defineViews(views: ViewSet) {
+      views.createContainerView(system, "omic-container", null).apply {
+        addDefaultElements()
+        add(Delius.system)
+        add(NOMIS.prisonApi)
+
+        setExternalSoftwareSystemBoundariesVisible(true)
+        enableAutomaticLayout()
+      }
     }
   }
 }

--- a/src/main/kotlin/model/OffenderManagementInCustody.kt
+++ b/src/main/kotlin/model/OffenderManagementInCustody.kt
@@ -29,7 +29,9 @@ class OffenderManagementInCustody private constructor() {
 
     override fun defineRelationships() {
       ldu.uses(Delius.system, "maintains 'shadow' team assignments for service users during prison-to-probation handover in")
-      allocationManager.uses(NOMIS.prisonApi, "polls service users currently in the logged in user's prison from")
+      allocationManager.uses(NOMIS.prisonApi, "pulls service users currently in the logged in user's prison from")
+      allocationManager.uses(NOMIS.offenderSearch, "pulls the 'recall' status of service users from")
+      allocationManager.uses(HMPPSAuth.system, "authenticates users via")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/OffenderManagementInCustody.kt
+++ b/src/main/kotlin/model/OffenderManagementInCustody.kt
@@ -23,10 +23,11 @@ class OffenderManagementInCustody private constructor() {
       allocationManager = system.addContainer("Offender Management Allocation Manager", "A service for allocating Prisoners to Prisoner Offender Managers (POMs)", "Ruby on Rails").apply {
         setUrl("https://github.com/ministryofjustice/offender-management-allocation-manager")
       }
+
+      allocationManager.delivers(ldu, "notifies community allocation requests to", "gov.uk notify")
     }
 
     override fun defineRelationships() {
-      ldu.uses(allocationManager, "notified about community allocation requests from", "gov.uk notify")
       ldu.uses(Delius.system, "maintains 'shadow' team assignments for service users during prison-to-probation handover in")
       allocationManager.uses(NOMIS.prisonApi, "polls service users currently in the logged in user's prison from")
     }


### PR DESCRIPTION
## What does this pull request do?

Adds a new container view, focussed on offender management in custody. The model was already there but I didn't export a view.

Naming and placement of elements in the model were also corrected.

**Result**
![structurizr-55488-omic-container](https://user-images.githubusercontent.com/1526295/93881769-412f2b80-fcd7-11ea-99a9-a5f2a050aed4.png)

## What is the intent behind these changes?

To be able to present an up-to-date OMiC container context directly via image links.