### PR TITLE
Use the correct name behind WMT acronym

### DIFF
--- a/src/main/kotlin/model/WMT.kt
+++ b/src/main/kotlin/model/WMT.kt
@@ -10,7 +10,7 @@ class WMT private constructor() {
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
-        "Workload Management Tool",
+        "Workload Measurement Tool",
         "(WMT) Helps probation practitioners schedule their time based on service user risk"
       )
     }


### PR DESCRIPTION
## What does this pull request do?

Corrects the name behind the `WMT` acronym.

## What is the intent behind these changes?

I recently saw a screenshot of the tool and it was using "Workload Measurement Tool", so it must be the correct one.