### PR TITLE
Capture that policy changes are recorded in EQuiP

### DIFF
--- a/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
+++ b/src/main/kotlin/defineModelWithDeprecatedSyntax.kt
@@ -14,11 +14,8 @@ fun defineModelWithDeprecatedSyntax(model: Model) {
   pom.uses(OffenderManagementInCustody.allocationManager, "look at service users who need handing over to community in")
 
   // lifted from probation model
-  val sentencingPolicy = model.addPerson("Sentencing Policy", "Pseudo-team to capture sentencing policy meeting participants")
-
   val hmip = model.addPerson("HM Inspectorate of Probation", "Reports to the government on the effectiveness of work with people who offended to reduce reoffending and protect the public")
 
-  EPF.projectManager.interactsWith(sentencingPolicy, "listens to owners of interventions for changes in policy")
   Reporting.ndmis.uses(OffenderManagementInCustody.allocationManager, "sends extracts containing service user allocation to", "email")
 
   hmip.uses(Reporting.ndmis, "uses data from")

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -26,6 +26,7 @@ private val MODEL_ITEMS = listOf(
   NOMIS,
   OASys,
   OffenderManagementInCustody,
+  PolicyTeams,
   PrepareCaseForCourt,
   PrisonerContentHub,
   PrisonToProbationUpdate,

--- a/src/main/kotlin/model/EPF.kt
+++ b/src/main/kotlin/model/EPF.kt
@@ -26,6 +26,7 @@ class EPF private constructor() {
     override fun defineRelationships() {
       projectManager.uses(system, "update intervention eligibility for accredited programmes in")
       projectManager.uses(system, "updates interventions table for discretionary services in")
+      projectManager.interactsWith(PolicyTeams.sentencingPolicy, "listens to owners of interventions for changes in policy")
       ProbationPractitioners.nps.uses(system, "enters court, location, offender needs, assessment score data to receive a shortlist of recommended interventions for Pre-Sentence Report Proposal from")
       ProbationPractitioners.nps.uses(system, "enters location, offender needs, assessment score data to receive recommended interventions for licence condition planning from")
       InterventionTeams.interventionServicesTeam.interactsWith(projectManager, "provide programme suitability guide for accredited programme eligibility to")

--- a/src/main/kotlin/model/EQuiP.kt
+++ b/src/main/kotlin/model/EQuiP.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
 import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
 
@@ -26,6 +27,10 @@ class EQuiP private constructor() {
     }
 
     override fun defineViews(views: ViewSet) {
+      views.createSystemContextView(system, "equip-context", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 500, 500)
+      }
     }
   }
 }

--- a/src/main/kotlin/model/EQuiP.kt
+++ b/src/main/kotlin/model/EQuiP.kt
@@ -12,13 +12,14 @@ class EQuiP private constructor() {
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
         "EQuiP",
-        "Central repository for all step-by-step business processes (in probation?)"
+        "Central repository for all step-by-step business processes and policy documents in probation"
       ).apply {
         ProblemArea.GETTING_THE_RIGHT_REHABILITATION.addTo(this)
       }
     }
 
     override fun defineRelationships() {
+      PolicyTeams.sentencingPolicy.uses(system, "updates policy changes in")
       ProbationPractitioners.crc.uses(system, "finds information about a process or software in")
       ProbationPractitioners.nps.uses(system, "finds information about a process or software in")
       ProbationPractitioners.nps.uses(system, "finds rate cards in")

--- a/src/main/kotlin/model/PolicyTeams.kt
+++ b/src/main/kotlin/model/PolicyTeams.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.Person
+import com.structurizr.view.ViewSet
+
+class PolicyTeams private constructor() {
+  companion object : HMPPSSoftwareSystem {
+    lateinit var sentencingPolicy: Person
+
+    override fun defineModelEntities(model: Model) {
+      sentencingPolicy = model.addPerson("Sentencing Policy", "Pseudo-team to capture sentencing policy meeting participants")
+    }
+
+    override fun defineRelationships() {
+    }
+
+    override fun defineViews(views: ViewSet) {
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Captures how policy is updated in EQuiP and adds a new system context diagram.

![structurizr-55488-equip-context](https://user-images.githubusercontent.com/1526295/94811024-bb089880-03ec-11eb-8f93-ba286f485e31.png)

## What is the intent behind these changes?

To make sure we can see how government policy is updated. As EQuiP is also the source of the process maps, it's an interesting hub of business change.