### PR TITLE
Update to a non-VPN community-api API docs link

### DIFF
--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -51,7 +51,7 @@ class Delius private constructor() {
         "Community API",
         "API over the nDelius DB used by HMPPS Digital team applications and services", "Java"
       ).apply {
-        APIDocs("https://community-api.test.delius.probation.hmpps.dsd.io/swagger-ui.html").addTo(this)
+        APIDocs("https://community-api-public.test.delius.probation.hmpps.dsd.io/swagger-ui.html").addTo(this)
         setUrl("https://github.com/ministryofjustice/community-api")
         uses(db, "connects to", "JDBC")
         ec2.add(this)


### PR DESCRIPTION
## What does this pull request do?

Updates the community-api API docs, based on changes in https://github.com/ministryofjustice/community-api/pull/274#pullrequestreview-503701850.

## What is the intent behind these changes?

Using non-VPN links makes life better for everyone 🎉 

We could now _parse_ the link from the repository directly...

![excellent](https://emoji.slack-edge.com/T045BEDPN/excellent/602757c71e32a04b.gif)