### PR TITLE
Add Azure deployment environment and AzureAD Justice tenant

### DIFF
--- a/src/main/kotlin/defineGlobalViews.kt
+++ b/src/main/kotlin/defineGlobalViews.kt
@@ -10,7 +10,7 @@ fun defineGlobalViews(model: Model, views: ViewSet) {
   views.createSystemLandscapeView("system-overview", "All systems").apply {
     addAllSoftwareSystems()
 
-    val noisySignOnSystems = listOf(HMPPSAuth.system, MoJSignOn.system)
+    val noisySignOnSystems = listOf(HMPPSAuth.system, MoJSignOn.system, AzureADTenantJusticeUK.system)
     val noisyHubSystems = listOf(NDH.system)
     noisySignOnSystems.forEach(::remove)
     noisyHubSystems.forEach(::remove)

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -8,6 +8,7 @@ import com.structurizr.model.Model
 import com.structurizr.view.ViewSet
 
 private val MODEL_ITEMS = listOf(
+  AzureADTenantJusticeUK,
   CaseNotesToProbation,
   CourtUsers,
   CRCSystem,
@@ -45,6 +46,7 @@ private fun defineModelItems(model: Model) {
   AWS.defineDeploymentNodes(model)
   CloudPlatform.defineDeploymentNodes(model)
   Heroku.defineDeploymentNodes(model)
+  Azure.defineDeploymentNodes(model)
 
   MODEL_ITEMS.forEach { it.defineModelEntities(model) }
   defineModelWithDeprecatedSyntax(model)

--- a/src/main/kotlin/model/Azure.kt
+++ b/src/main/kotlin/model/Azure.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.DeploymentNode
+import com.structurizr.model.Model
+
+class Azure private constructor() {
+  companion object {
+    lateinit var root: DeploymentNode
+
+    fun defineDeploymentNodes(model: Model) {
+      root = model.addDeploymentNode("Microsoft Azure", "Azure platform", "Azure")
+    }
+  }
+}

--- a/src/main/kotlin/model/AzureADTenantJusticeUK.kt
+++ b/src/main/kotlin/model/AzureADTenantJusticeUK.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Container
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.ViewSet
+
+class AzureADTenantJusticeUK private constructor() {
+  companion object : HMPPSSoftwareSystem {
+    lateinit var directory: Container
+    lateinit var system: SoftwareSystem
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem(
+        "Azure AD JusticeUK Tenant",
+        "Azure AD tenant synced with uses from the on-prem Atos AD domain (DOM1)"
+      )
+
+      directory = system.addContainer(
+        "JusticeUK Directory",
+        "Directory service containing DOM1 identities",
+        "Azure AD"
+      ).apply {
+        Azure.root.add(this)
+      }
+    }
+
+    override fun defineRelationships() {
+    }
+
+    override fun defineViews(views: ViewSet) {
+    }
+  }
+}

--- a/src/main/kotlin/model/HMPPSAuth.kt
+++ b/src/main/kotlin/model/HMPPSAuth.kt
@@ -38,9 +38,14 @@ class HMPPSAuth private constructor() {
     override fun defineRelationships() {
       app.uses(NOMIS.db, "authenticates via")
       app.uses(Delius.communityApi, "authenticates via")
+      app.uses(AzureADTenantJusticeUK.directory, "authenticates via")
     }
 
     override fun defineViews(views: ViewSet) {
+      views.createSystemContextView(system, "hmpps-auth-context", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout()
+      }
     }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

* Adds a system context diagram for HMPPS-Auth
* Adds the Azure deployment environment
* Adds the AzureAD Justice UK tenant which contains DOM1 identities 

## What is the intent behind these changes?

Visualising the authentication environment and adding a new identity provider system
