### PR TITLE
Adds first pass of planned intervention architecture (it will evolve)

### DIFF
--- a/src/main/kotlin/annotations/Tags.kt
+++ b/src/main/kotlin/annotations/Tags.kt
@@ -4,6 +4,7 @@ import com.structurizr.model.Element
 
 enum class Tags : addTo {
   DATABASE,
+  QUEUE,
   WEB_BROWSER,
   PROVIDER {
     override fun addTo(element: Element) {

--- a/src/main/kotlin/annotations/Tags.kt
+++ b/src/main/kotlin/annotations/Tags.kt
@@ -11,6 +11,7 @@ enum class Tags : addTo {
       OutsideHMPPS.addTo(element)
     }
   },
+  PLANNED,
   DEPRECATED,
   SOFTWARE_AS_A_SERVICE;
 

--- a/src/main/kotlin/defineStyles.kt
+++ b/src/main/kotlin/defineStyles.kt
@@ -10,6 +10,7 @@ fun defineStyles(styles: Styles) {
   styles.addElementStyle("Person").shape(Shape.Person).background("#aabbdd")
 
   styles.addElementStyle(Tags.DATABASE.toString()).shape(Shape.Cylinder)
+  styles.addElementStyle(Tags.QUEUE.toString()).shape(Shape.Pipe)
   styles.addElementStyle(Tags.WEB_BROWSER.toString()).shape(Shape.WebBrowser)
   styles.addElementStyle(Tags.PLANNED.toString()).border(Border.Dotted).opacity(50)
 

--- a/src/main/kotlin/defineStyles.kt
+++ b/src/main/kotlin/defineStyles.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.hmpps.architecture
 
+import com.structurizr.view.Border
 import com.structurizr.view.Shape
 import com.structurizr.view.Styles
 import uk.gov.justice.hmpps.architecture.annotations.Tags
@@ -9,8 +10,8 @@ fun defineStyles(styles: Styles) {
   styles.addElementStyle("Person").shape(Shape.Person).background("#aabbdd")
 
   styles.addElementStyle(Tags.DATABASE.toString()).shape(Shape.Cylinder)
-
   styles.addElementStyle(Tags.WEB_BROWSER.toString()).shape(Shape.WebBrowser)
+  styles.addElementStyle(Tags.PLANNED.toString()).border(Border.Dotted).opacity(50)
 
   styles.addElementStyle(Tags.PROVIDER.toString()).background("#ccff99")
   styles.addElementStyle(Tags.DEPRECATED.toString()).background("#999999")

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -18,6 +18,7 @@ private val MODEL_ITEMS = listOf(
   EQuiP,
   HMPPSAuth,
   IM,
+  Interventions,
   InterventionTeams,
   Licences,
   MoJSignOn,

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.Workspace
-import com.structurizr.model.CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy
+import com.structurizr.model.CreateImpliedRelationshipsUnlessSameRelationshipExistsStrategy
 import com.structurizr.model.Enterprise
 import com.structurizr.model.Location
 import com.structurizr.model.Model
@@ -42,7 +42,7 @@ private val MODEL_ITEMS = listOf(
 
 private fun defineModelItems(model: Model) {
   model.setImpliedRelationshipsStrategy(
-    CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy()
+    CreateImpliedRelationshipsUnlessSameRelationshipExistsStrategy()
   )
 
   AWS.defineDeploymentNodes(model)

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -8,6 +8,7 @@ import com.structurizr.model.Model
 import com.structurizr.view.ViewSet
 
 private val MODEL_ITEMS = listOf(
+  AnalyticalPlatform,
   AzureADTenantJusticeUK,
   CaseNotesToProbation,
   CourtUsers,

--- a/src/main/kotlin/model/AnalyticalPlatform.kt
+++ b/src/main/kotlin/model/AnalyticalPlatform.kt
@@ -13,7 +13,7 @@ class AnalyticalPlatform private constructor() {
       val platform = model.addSoftwareSystem("Analytical Platform")
       landingBucket = platform.addContainer(
         "Analytical Platform landing bucket",
-        "Storage area where data ingestion for reporting, analytics, data science starts",
+        "Storage area where data ingestion for analytics and data science starts",
         "S3"
       ).apply {
         Tags.DATABASE.addTo(this)

--- a/src/main/kotlin/model/AnalyticalPlatform.kt
+++ b/src/main/kotlin/model/AnalyticalPlatform.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Container
+import com.structurizr.model.Model
+import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.Tags
+
+class AnalyticalPlatform private constructor() {
+  companion object : HMPPSSoftwareSystem {
+    lateinit var landingBucket: Container
+
+    override fun defineModelEntities(model: Model) {
+      val platform = model.addSoftwareSystem("Analytical Platform")
+      landingBucket = platform.addContainer(
+        "Analytical Platform landing bucket",
+        "Storage area where data ingestion for reporting, analytics, data science starts",
+        "S3"
+      ).apply {
+        Tags.DATABASE.addTo(this)
+      }
+    }
+
+    override fun defineRelationships() {
+    }
+
+    override fun defineViews(views: ViewSet) {
+    }
+  }
+}

--- a/src/main/kotlin/model/HMPPSAuth.kt
+++ b/src/main/kotlin/model/HMPPSAuth.kt
@@ -16,10 +16,11 @@ class HMPPSAuth private constructor() {
       system = model.addSoftwareSystem("HMPPS Auth", "Allows users to login into digital services")
 
       app = system.addContainer(
-        "API",
-        "OAuth2 server integrating with NOMIS database, nDelius (via community api) and an auth database for storing external users",
+        "HMPPS Auth",
+        "UI and OAuth2 server integrating with NOMIS database, nDelius (via community api) and an auth database for storing external users",
         "Spring Boot + Java"
       ).apply {
+        Tags.WEB_BROWSER.addTo(this)
         APIDocs("https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/swagger-ui.html").addTo(this)
         setUrl("https://github.com/ministryofjustice/hmpps-auth")
       }

--- a/src/main/kotlin/model/InterventionTeams.kt
+++ b/src/main/kotlin/model/InterventionTeams.kt
@@ -10,8 +10,11 @@ class InterventionTeams private constructor() {
     lateinit var interventionServicesTeam: Person
     lateinit var npsTreatmentManager: Person
     lateinit var contractManagerForCRC: Person
+
     lateinit var crcTreatmentManager: Person
     lateinit var crcProgrammeManager: Person
+
+    lateinit var dynamicFrameworkProvider: Person
 
     override fun defineModelEntities(model: Model) {
       interventionServicesTeam = model.addPerson(
@@ -28,6 +31,14 @@ class InterventionTeams private constructor() {
         "CRC programme manager",
         "People who provide interventions on behalf of Community Rehabilitation Companies"
       ).apply { Tags.PROVIDER.addTo(this) }
+
+      dynamicFrameworkProvider = model.addPerson(
+        "Dynamic Framework service provider",
+        "Contracted providers delivering rehabilitation and resettlement interventions for service users"
+      ).apply {
+        Tags.PROVIDER.addTo(this)
+        Tags.PLANNED.addTo(this)
+      }
 
       crcProgrammeManager.interactsWith(contractManagerForCRC, "sends rate card brochure to")
     }

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -86,6 +86,12 @@ class Interventions private constructor() {
         CloudPlatform.kubernetes.add(this)
       }
 
+      val unknownReporting = model.addSoftwareSystem(
+        "Unknown Reporting Pipeline",
+        "It is currently undefined where we push data for reporting purposes (we want to avoid using live systems)"
+      )
+      collector.uses(unknownReporting, "pushes intervention data daily to")
+
       system.containers.forEach { Tags.PLANNED.addTo(it) }
     }
 

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -56,8 +56,9 @@ class Interventions private constructor() {
       publish.uses(HMPPSAuth.app, "authenticates, authorises users and requests access tokens from", "OAuth2/JWT")
       deliver.uses(HMPPSAuth.app, "authenticates, authorises users and requests access tokens from", "OAuth2/JWT")
 
-      deliver.uses(OASys.assessmentsApi, "retrieves service user risks and needs via", "REST/HTTP")
-      deliver.uses(Delius.offenderSearch, "retrieves service user information via", "REST/HTTP")
+      deliver.uses(Delius.communityApi, "retrieves current service user appointments from", "REST/HTTP")
+      deliver.uses(OASys.assessmentsApi, "retrieves service user risks and needs from", "REST/HTTP")
+      deliver.uses(Delius.offenderSearch, "searches service user by identity and gets identification details from", "REST/HTTP")
 
       InterventionTeams.dynamicFrameworkProvider.uses(publishUI, "maintains directory of dynamic framework interventions and services in")
       InterventionTeams.dynamicFrameworkProvider.uses(deliverUI, "tracks delivery of dynamic framework interventions and services in")
@@ -74,6 +75,12 @@ class Interventions private constructor() {
       views.createContainerView(system, "interventions-container", "Container overview of the digital intervention services").apply {
         addDefaultElements()
         system.containers.forEach(::addNearestNeighbours)
+
+        // relationships between the dependencies are not important for this view
+        // would be nice to have `removeRelationshipsNotConnectedTo(system.containers)`
+        // or the ability to set a default for relationships between imported neighbour elements
+        HMPPSAuth.app.getEfferentRelationshipsWith(Delius.communityApi).forEach(::remove)
+
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
       }
     }

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Container
 import com.structurizr.model.Model
-import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -108,7 +108,7 @@ class Interventions private constructor() {
       views.createSystemContextView(system, "interventions-context", "Context overview of the digital intervention services").apply {
         addDefaultElements()
         removeRelationshipsNotConnectedToElement(system)
-        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 500, 500)
       }
 
       views.createDeploymentView(system, "interventions-deployment", "Deployment overview of the digital intervention services").apply {
@@ -125,7 +125,8 @@ class Interventions private constructor() {
         // or the ability to set a default for relationships between imported neighbour elements
         HMPPSAuth.app.getEfferentRelationshipsWith(Delius.communityApi).forEach(::remove)
 
-        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+        setExternalSoftwareSystemBoundariesVisible(true)
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 250, 150)
       }
     }
   }

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Container
+import com.structurizr.model.Model
+import com.structurizr.model.Person
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.AutomaticLayout
+import com.structurizr.view.ViewSet
+import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
+import uk.gov.justice.hmpps.architecture.annotations.Tags
+
+class Interventions private constructor() {
+  companion object : HMPPSSoftwareSystem {
+    lateinit var system: SoftwareSystem
+    lateinit var publishUI: Container
+    lateinit var publish: Container
+    lateinit var deliverUI: Container
+    lateinit var deliver: Container
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem(
+        "Getting the right rehabilitation",
+        "Supports maintaning interventions and services and finding, booking, delivering and monitoring interventions (currently only Dynamic Framework)"
+      ).apply {
+        ProblemArea.GETTING_THE_RIGHT_REHABILITATION.addTo(this)
+        Tags.PLANNED.addTo(this)
+      }
+
+      publish = system.addContainer(
+        "Publish an intervention service",
+        "Responsible for curating published interventions and services",
+        "Java or Kotlin"
+      )
+
+      deliver = system.addContainer(
+        "Deliver an intervention service",
+        "Responsible for tracking referrals, appointments and the delivery for interventions and services",
+        "Java or Kotlin"
+      )
+
+      publishUI = system.addContainer("Publish an intervention UI", "Responsible for curating published interventions and services", "node").apply {
+        uses(publish, "adds, quality checks and revokes interventions with")
+        Tags.WEB_BROWSER.addTo(this)
+      }
+
+      deliverUI = system.addContainer("Find, book, record, monitor an intervention UI", "Responsible for intervention delivery", "node").apply {
+        uses(publish, "finds interventions with")
+        uses(deliver, "books, schedules, delivers and monitors interventions with")
+        Tags.WEB_BROWSER.addTo(this)
+      }
+
+      system.containers.forEach { Tags.PLANNED.addTo(it) }
+    }
+
+    override fun defineRelationships() {
+      publish.uses(HMPPSAuth.app, "authenticates, authorises users and requests access tokens from", "OAuth2/JWT")
+      deliver.uses(HMPPSAuth.app, "authenticates, authorises users and requests access tokens from", "OAuth2/JWT")
+
+      deliver.uses(OASys.assessmentsApi, "retrieves service user risks and needs via", "REST/HTTP")
+      deliver.uses(Delius.offenderSearch, "retrieves service user information via", "REST/HTTP")
+    }
+
+    override fun defineViews(views: ViewSet) {
+      views.createSystemContextView(system, "interventions-context", "Context overview of the digital intervention services").apply {
+        addDefaultElements()
+        removeRelationshipsNotConnectedToElement(system)
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+
+      views.createContainerView(system, "interventions-container", "Container overview of the digital intervention services").apply {
+        addDefaultElements()
+        system.containers.forEach(::addNearestNeighbours)
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -53,13 +53,26 @@ class Interventions private constructor() {
     }
 
     override fun defineRelationships() {
+      defineAuthentication()
+      defineSharing()
+      defineUsers()
+    }
+
+    fun defineAuthentication() {
       publish.uses(HMPPSAuth.app, "authenticates, authorises users and requests access tokens from", "OAuth2/JWT")
       deliver.uses(HMPPSAuth.app, "authenticates, authorises users and requests access tokens from", "OAuth2/JWT")
+    }
+
+    fun defineSharing() {
+      publish.uses(Delius.communityApi, "retrieves list of dynamic framework providers and probation regions from", "REST/HTTP")
+      publish.uses(OASys.assessmentsApi, "retrieves list of needs from", "REST/HTTP")
 
       deliver.uses(Delius.communityApi, "retrieves current service user appointments from", "REST/HTTP")
-      deliver.uses(OASys.assessmentsApi, "retrieves service user risks and needs from", "REST/HTTP")
-      deliver.uses(Delius.offenderSearch, "searches service user by identity and gets identification details from", "REST/HTTP")
+      deliver.uses(OASys.assessmentsApi, "retrieves service user current risks and needs from", "REST/HTTP")
+      deliver.uses(Delius.offenderSearch, "searches service user by identity and gets basic identification details from", "REST/HTTP")
+    }
 
+    fun defineUsers() {
       InterventionTeams.dynamicFrameworkProvider.uses(publishUI, "maintains directory of dynamic framework interventions and services in")
       InterventionTeams.dynamicFrameworkProvider.uses(deliverUI, "tracks delivery of dynamic framework interventions and services in")
       ProbationPractitioners.nps.uses(deliverUI, "refers and monitors progress of their service users' interventions and services")

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -102,7 +102,11 @@ class Interventions private constructor() {
     }
 
     fun defineAuthentication() {
-      service.uses(HMPPSAuth.app, "authenticates, authorises users and requests access tokens from", "OAuth2/JWT")
+      InterventionTeams.dynamicFrameworkProvider.uses(HMPPSAuth.app, "log in via", "HTTPS/web")
+      ProbationPractitioners.nps.uses(HMPPSAuth.app, "log in via", "HTTPS/web")
+
+      ui.uses(HMPPSAuth.app, "requests access tokens from", "OAuth2/JWT")
+      service.uses(HMPPSAuth.app, "authorises users and requests access tokens from", "OAuth2/JWT")
     }
 
     fun defineSharing() {

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -37,7 +37,7 @@ class Interventions private constructor() {
 
       ui = system.addContainer(
         "Intervention UI",
-        "Responsible for curating published interventions and services",
+        "Responsible for curating and delivering published interventions and services",
         "Node + Express"
       ).apply {
         uses(service, "implements intervention processes via")

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -58,6 +58,10 @@ class Interventions private constructor() {
 
       deliver.uses(OASys.assessmentsApi, "retrieves service user risks and needs via", "REST/HTTP")
       deliver.uses(Delius.offenderSearch, "retrieves service user information via", "REST/HTTP")
+
+      InterventionTeams.dynamicFrameworkProvider.uses(publishUI, "maintains directory of dynamic framework interventions and services in")
+      InterventionTeams.dynamicFrameworkProvider.uses(deliverUI, "tracks delivery of dynamic framework interventions and services in")
+      ProbationPractitioners.nps.uses(deliverUI, "refers and monitors progress of their service users' interventions and services")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -31,15 +31,18 @@ class Interventions private constructor() {
         "Intervention service",
         "Tracks the lifecycle of dynamic framework interventions and services, including publishing, finding, referring, delivering and monitoring",
         "Java or Kotlin"
-      )
+      ).apply {
+        CloudPlatform.kubernetes.add(this)
+      }
 
       ui = system.addContainer(
         "Intervention UI",
         "Responsible for curating published interventions and services",
-        "node"
+        "Node + Express"
       ).apply {
         uses(service, "implements intervention processes via")
         Tags.WEB_BROWSER.addTo(this)
+        CloudPlatform.kubernetes.add(this)
       }
 
       database = system.addContainer(
@@ -50,6 +53,7 @@ class Interventions private constructor() {
       ).apply {
         service.uses(this, "connects to", "JDBC")
         Tags.DATABASE.addTo(this)
+        CloudPlatform.rds.add(this)
       }
 
       queue = system.addContainer(
@@ -104,6 +108,11 @@ class Interventions private constructor() {
       views.createSystemContextView(system, "interventions-context", "Context overview of the digital intervention services").apply {
         addDefaultElements()
         removeRelationshipsNotConnectedToElement(system)
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+
+      views.createDeploymentView(system, "interventions-deployment", "Deployment overview of the digital intervention services").apply {
+        addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
       }
 

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -91,7 +91,7 @@ class Interventions private constructor() {
 
     fun defineSharing() {
       service.uses(Delius.communityApi, "retrieves list of dynamic framework providers and probation regions from", "REST/HTTP")
-      service.uses(Delius.communityApi, "retrieves current service user appointments from", "REST/HTTP")
+      service.uses(Delius.communityApi, "retrieves current service user appointments and sentence details from", "REST/HTTP")
       service.uses(Delius.offenderSearch, "searches service user by identity and gets basic identification details from", "REST/HTTP")
       service.uses(OASys.assessmentsApi, "retrieves service user current risks and needs from", "REST/HTTP")
 

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -113,6 +113,9 @@ class Interventions private constructor() {
     fun defineUsers() {
       InterventionTeams.dynamicFrameworkProvider.uses(ui, "maintains directory and delivery of dynamic framework interventions and services in")
       ProbationPractitioners.nps.uses(ui, "refers and monitors progress of their service users' interventions and services in")
+
+      service.delivers(InterventionTeams.dynamicFrameworkProvider, "emails new referrals", "gov.uk notify")
+      service.delivers(ProbationPractitioners.nps, "emails attendance and safeguarding issues", "gov.uk notify")
     }
 
     override fun defineViews(views: ViewSet) {


### PR DESCRIPTION
## What does this pull request do?

Defines the target architecture for the new dynamic framework digital service.

ℹ️ Everything faded out is `planned` and does not exist yet -- up for debate and review.

⚠️ I arranged this diagram manually. The generated layout has the same nodes but quite a useless layout 😢 I'm working on that on a separate branch.

### Annotations

- `community-api` will have to change
- `intervention-probation-translator` may be done within `community-api` itself; it depends whether we can work together, or need to do push to other services ourselves

### C4 container diagram

![structurizr-55488-interventions-container(6)](https://user-images.githubusercontent.com/1526295/97927506-00f2ac80-1d5d-11eb-882f-0f71f9daefd1.png)


## What is the intent behind these changes?

To be able to share the existing thinking around what's required for integration and what the first pass will be for the beta phase.