### PR TITLE
Add interventions architecture decision records

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation("com.structurizr:structurizr-client:1.4.5")
     implementation("com.structurizr:structurizr-core:1.4.5")
+    implementation("com.structurizr:structurizr-adr-tools:1.3.6")
 }

--- a/decisions/interventions/0001-split-ui-and-service.md
+++ b/decisions/interventions/0001-split-ui-and-service.md
@@ -1,4 +1,4 @@
-# 1. Split user and service interfaces by default
+# 1. Split user and business interfaces by default
 
 Date: 2020-11-02
 
@@ -15,13 +15,24 @@ The Ministry of Justice 2022 Digital Strategy defines "Building sustainable serv
 As the domain model of HM Prisons and Probation Service (HMPPS) is big, we aim to build sustainable services
 around [bounded contexts][bounded-context], making it necessary to integrate with other contexts.
 
-### Business logic drift
+### Domain and business logic
 
 Historically, many systems built in HMPPS did not expose an API for the business logic and/or were managed by third
 parties, leading to difficult integration: we see business APIs beneficial to have from the start.
 
-We have also seen services with a frontend/backend split where frontend clients accumulated business logic as the
+Existing APIs that are thin layers over a database (entity services) are easy to write but hard to use as it pushes
+the need to handle business logic back to the clients.
+
+We have seen services with a frontend/backend split where frontend clients accumulated business logic as the
 backend service fell back to provide a CRUD entity service over the database; this is not sustainable.
+
+_Sam Newman_ writes in _Monolith to Microservices_ (O'Reilly, 2019):
+
+> Fundamentally, in a system that consists of multiple independent services, there has to be some interaction between
+> the participants. In a microservice architecture, _domain coupling_ is the result—the interactions between services
+> model the interactions in our real domain.
+
+We want to aim for domain-level coupling to avoid business logic drifting into current and future clients.
 
 ### Languages in "adopt"
 
@@ -33,17 +44,18 @@ and happy working with multiple languages.
 
 The department's talent pool reflects this split; there are:
 
-- many node.js focussed frontend specialists,
-- many Java/Kotlin focussed backend specialists,
-- and a few full-stack developers.
+- many node-focussed frontend specialists,
+- many Java/Kotlin-focussed backend specialists,
+- a few full-stack developers.
 
 ## Decision
 
-We will **create standalone service interfaces (business APIs) by default**.
+We will **create standalone business interfaces (business/domain APIs) by default**.
 
-We will **split the user interface** from the API's component to enforce the use of the business API by default.
+We will **split the user interface** from the API's component to enforce the use of the business API by default
+and better utilise the talent we have.
 
-We realise this is an optimisation.
+We realise this is an optimisation to build durable domain-coupled systems at the cost of some team autonomy.
 
 ## Consequences
 
@@ -55,10 +67,12 @@ We realise this is an optimisation.
 
 **Challenges**
 
+- We need to be more careful on what services we create and what API they have. This increases _governance_,
+  which we must keep lightweight.
 - Contracts between the UI and the service components will take a while to stabilise, creating churn in the beginning.
 - Expectations between the parts have to be clear to avoid blocking others or taking up time. [Consumer-driven contract testing][cdct] can mitigate.
 
-In short, we gain _sustainability_ benefits by trading off governance around the API contracts.
+In short, we gain _sustainability_ benefits by trading off _governance_ around the API contracts.
 
 [radar]: https://ministryofjustice.github.io/hmpps-digital-tech-radar/docs/index.html
 [cdct]: https://www.thoughtworks.com/radar/techniques/consumer-driven-contract-testing

--- a/decisions/interventions/0001-split-ui-and-service.md
+++ b/decisions/interventions/0001-split-ui-and-service.md
@@ -1,4 +1,4 @@
-# 1. Split user interface and service by default
+# 1. Split user and service interfaces by default
 
 Date: 2020-11-02
 
@@ -8,11 +8,28 @@ Proposed
 
 ## Context
 
-The [current HMPPS Digital tech radar][radar] elects Java, Kotlin and node.js as languages in _adopt_. It also
-mentions Ruby (for London); however, the current direction is to reduce regional differences as it is difficult
-to hire developers who are comfortable and happy working with multiple languages.
+### Need for sustainable services
 
-In short, HMPPS Digital is heading towards using Java, Kotlin and node.js as their primary choices.
+The Ministry of Justice 2022 Digital Strategy defines "Building sustainable services" as a priority.
+
+As the domain model of HM Prisons and Probation Service (HMPPS) is big, we aim to build sustainable services
+around [bounded contexts][bounded-context], making it necessary to integrate with other contexts.
+
+### Business logic drift
+
+Historically, many systems built in HMPPS did not expose an API for the business logic and/or were managed by third
+parties, leading to difficult integration: we see business APIs beneficial to have from the start.
+
+We have also seen services with a frontend/backend split where frontend clients accumulated business logic as the
+backend service fell back to provide a CRUD entity service over the database; this is not sustainable.
+
+### Languages in "adopt"
+
+HMPPS Digital is heading towards using Java/Kotlin and node.js as their primary language choices.
+
+The [current HMPPS Digital tech radar][radar] elects the mentioned languages in _adopt_. It also mentions Ruby (for London);
+however, the current direction is to reduce regional differences as it is difficult to hire developers who are comfortable
+and happy working with multiple languages.
 
 The department's talent pool reflects this split; there are:
 
@@ -20,31 +37,29 @@ The department's talent pool reflects this split; there are:
 - many Java/Kotlin focussed backend specialists,
 - and a few full-stack developers.
 
-### Team
-
-The current interventions team is mostly on a timed contract with a managed service provider.
-When their contract runs out, we need to be able to backfill developers.
-
-Consequently, we need to choose a technology stack that most other developers in HMPPS already know.
-
 ## Decision
 
-To reflect the available talent pool in our department, we will **split the interventions service into a UI
-and a service component**.
+We will **create standalone service interfaces (business APIs) by default**.
+
+We will **split the user interface** from the API's component to enforce the use of the business API by default.
+
+We realise this is an optimisation.
 
 ## Consequences
 
 **Benefits**
 
+- The APIs we create can be used by other teams if they wish to hook into our business processes.
+- There are reusable best practices already available from DPS for separate API components.
 - The pool of talent who can join our team from HMPPS is larger.
-- There are reusable best practices already available from DPS.
 
 **Challenges**
 
-- Contracts between the UI component and the service component will take a while to stabilise, creating churn in the beginning.
+- Contracts between the UI and the service components will take a while to stabilise, creating churn in the beginning.
 - Expectations between the parts have to be clear to avoid blocking others or taking up time. [Consumer-driven contract testing][cdct] can mitigate.
 
-In short, we gain _maintainability_ benefits by trading off initial speed.
+In short, we gain _sustainability_ benefits by trading off governance around the API contracts.
 
 [radar]: https://ministryofjustice.github.io/hmpps-digital-tech-radar/docs/index.html
 [cdct]: https://www.thoughtworks.com/radar/techniques/consumer-driven-contract-testing
+[bounded-context]: https://martinfowler.com/bliki/BoundedContext.html

--- a/decisions/interventions/0001-split-ui-and-service.md
+++ b/decisions/interventions/0001-split-ui-and-service.md
@@ -1,0 +1,50 @@
+# 1. Split user interface and service by default
+
+Date: 2020-11-02
+
+## Status
+
+Proposed
+
+## Context
+
+The [current HMPPS Digital tech radar][radar] elects Java, Kotlin and node.js as languages in _adopt_. It also
+mentions Ruby (for London); however, the current direction is to reduce regional differences as it is difficult
+to hire developers who are comfortable and happy working with multiple languages.
+
+In short, HMPPS Digital is heading towards using Java, Kotlin and node.js as their primary choices.
+
+The department's talent pool reflects this split; there are:
+
+- many node.js focussed frontend specialists,
+- many Java/Kotlin focussed backend specialists,
+- and a few full-stack developers.
+
+### Team
+
+The current interventions team is mostly on a timed contract with a managed service provider.
+When their contract runs out, we need to be able to backfill developers.
+
+Consequently, we need to choose a technology stack that most other developers in HMPPS already know.
+
+## Decision
+
+To reflect the available talent pool in our department, we will **split the interventions service into a UI
+and a service component**.
+
+## Consequences
+
+**Benefits**
+
+- The pool of talent who can join our team from HMPPS is larger.
+- There are reusable best practices already available from DPS.
+
+**Challenges**
+
+- Contracts between the UI component and the service component will take a while to stabilise, creating churn in the beginning.
+- Expectations between the parts have to be clear to avoid blocking others or taking up time. [Consumer-driven contract testing][cdct] can mitigate.
+
+In short, we gain _maintainability_ benefits by trading off initial speed.
+
+[radar]: https://ministryofjustice.github.io/hmpps-digital-tech-radar/docs/index.html
+[cdct]: https://www.thoughtworks.com/radar/techniques/consumer-driven-contract-testing

--- a/decisions/interventions/0002-decouple-with-events.md
+++ b/decisions/interventions/0002-decouple-with-events.md
@@ -18,6 +18,15 @@ In the current probation programme landscape, we expect
 - many changes to existing systems,
 - different times when integration happens as teams will have separate priorities.
 
+Specifically, we will have other teams to
+
+- assess risks and needs,
+- manage a sentence,
+- manage a supervision in the community,
+- manage my progress.
+
+All of these teams would have interest in actions carried out in interventions.
+
 ### Nature of probation
 
 Additionally, probation

--- a/decisions/interventions/0002-decouple-with-events.md
+++ b/decisions/interventions/0002-decouple-with-events.md
@@ -1,0 +1,73 @@
+# 2. Decouple with events
+
+Date: 2020-11-02
+
+## Status
+
+Proposed
+
+## Context
+
+The Dynamic Framework interventions are the first intervention type onboarded by this system.
+
+### Many new teams
+
+In the current probation programme landscape, we expect
+
+- many new digital teams,
+- many changes to existing systems,
+- different times when integration happens as teams will have separate priorities.
+
+### Nature of probation
+
+Additionally, probation
+
+- reacts to what happened in real-life with the supervised service users,
+- has various priorities, depending on what happened.
+
+## Decision
+
+The above qualities point towards a decentralised way of integration and notifying each other.
+
+**We will use _domain_ events to decouple** from other production services.
+
+For example, our events may be:
+
+- intervention completed
+- service user appointment booked
+- (many others)
+
+----
+
+### Unsure about this one, help please 🙇‍♂️
+
+Some consumers may need to build a local (materialised) view of events that happened in the past, even if
+they join the landscape later.
+
+For this use case, **we will also create an event log**, internal to our service.
+
+----
+
+## Consequences
+
+We will build our intervention services to emit known significant domain events by default.
+
+**Benefits**
+
+- The decoupling allows developing almost all user stories without waiting for integrations.
+- New and old systems can join as consumers any time.
+- Consumers can test their integration with us without running our service.
+
+**Challenges**
+
+- This architecture is asynchronous and distributed:
+  - Request tracking and error handling needs to be built-in to understand what happens in production.
+  - It is harder to setup a certain state for pre-production testing as we have to know what events have to happen.
+- Lack of atomic transactions:
+  - We must not use events that need to be rolled back as a result of a consumer failing to process them.
+- Creation, maintenance, and governance of the event contracts is difficult:
+  - We need to version the events from the beginning, to avoid backwards-incompatible changes blocking consumers.
+  - We need to use event names that are aligned and understood by everyone in HMPPS.
+  - We need to document which services emit which events to make discovery and testing easier.
+
+In short, _governance_ will have a much more important role.

--- a/decisions/interventions/0002-decouple-with-events.md
+++ b/decisions/interventions/0002-decouple-with-events.md
@@ -40,22 +40,23 @@ The above qualities point towards a decentralised way of integration and notifyi
 
 **We will use _domain_ events to decouple** from other production services.
 
+Our domain event payloads will contain:
+
+- transport-specific concerns, e.g. request and tracking IDs, publishing timestamps, etc.
+- domain context, e.g. URL on how to find out more, intervention ID, service user ID, etc.
+- core domain data, which is required to make sense of the event
+
+The payloads will **not** contain further data by default. **Consumers can request further details via the business API**.
+
+We do not intend to build event sourcing. We will **not** build event logs by default.
+
+**Examples**
+
 For example, our events may be:
 
 - intervention completed
 - service user appointment booked
 - (many others)
-
-----
-
-### Unsure about this one, help please 🙇‍♂️
-
-Some consumers may need to build a local (materialised) view of events that happened in the past, even if
-they join the landscape later.
-
-For this use case, **we will also create an event log**, internal to our service.
-
-----
 
 ## Consequences
 
@@ -63,15 +64,18 @@ We will build our intervention services to emit known significant domain events 
 
 **Benefits**
 
-- The decoupling allows developing almost all user stories without waiting for integrations.
+- The decoupling allows us developing almost all user stories without waiting on endpoints to be finished.
 - New and old systems can join as consumers any time.
-- Consumers can test their integration with us without running our service.
+- We contribute to an event _vocabulary_ for probation, enabling systems with similar responsibilities to
+  start publishing the same events.
+- Same events from different systems enables us to start using the strangler fig pattern
+  by moving the source of those events elsewhere.
 
 **Challenges**
 
 - This architecture is asynchronous and distributed:
   - Request tracking and error handling needs to be built-in to understand what happens in production.
-  - It is harder to setup a certain state for pre-production testing as we have to know what events have to happen.
+  - It is harder to set up a certain state for pre-production testing as we have to know what events have to happen.
 - Lack of atomic transactions:
   - We must not use events that need to be rolled back as a result of a consumer failing to process them.
 - Creation, maintenance, and governance of the event contracts is difficult:

--- a/src/main/kotlin/DefinesDecisions.kt
+++ b/src/main/kotlin/DefinesDecisions.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.Workspace
+
+interface DefinesDecisions {
+  fun defineDecisions(workspace: Workspace)
+}

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -71,6 +71,11 @@ private fun defineViews(model: Model, views: ViewSet) {
   defineGlobalViews(model, views)
 }
 
+private fun defineDecisionsAndDocumentation(workspace: Workspace) {
+  MODEL_ITEMS.filterIsInstance<DefinesDecisions>().forEach { it.defineDecisions(workspace) }
+  defineDocumentation(workspace)
+}
+
 fun defineWorkspace(): Workspace {
   val enterprise = Enterprise("HM Prison and Probation Service")
   val workspace = Workspace(enterprise.name, "Systems related to the custody and probation of offenders")
@@ -83,7 +88,7 @@ fun defineWorkspace(): Workspace {
   defineRelationships()
   defineViews(workspace.model, workspace.views)
   defineStyles(workspace.views.configuration.styles)
-  defineDocumentation(workspace)
+  defineDecisionsAndDocumentation(workspace)
 
   return workspace
 }

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -6,6 +6,7 @@ import com.structurizr.util.WorkspaceUtils
 import java.io.File
 
 object App {
+  val DECISIONS_LOCATION = File("./decisions")
   val EXPORT_LOCATION = File("./exports")
 
   @JvmStatic

--- a/src/main/kotlin/model/DigitalPrisonsNetwork.kt
+++ b/src/main/kotlin/model/DigitalPrisonsNetwork.kt
@@ -4,8 +4,6 @@ import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
-import uk.gov.justice.hmpps.architecture.annotations.APIDocs
-import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class DigitalPrisonsNetwork private constructor() {
   companion object : HMPPSSoftwareSystem {

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.hmpps.architecture
 
+import com.structurizr.documentation.AdrToolsImporter
 import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
@@ -9,7 +10,7 @@ import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
 import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class Interventions private constructor() {
-  companion object : HMPPSSoftwareSystem {
+  companion object : HMPPSSoftwareSystem, DefinesDecisions {
     lateinit var system: SoftwareSystem
     lateinit var ui: Container
     lateinit var service: Container
@@ -151,6 +152,10 @@ class Interventions private constructor() {
         setExternalSoftwareSystemBoundariesVisible(true)
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 250, 150)
       }
+    }
+
+    override fun defineDecisions(workspace: com.structurizr.Workspace) {
+      AdrToolsImporter(workspace, App.DECISIONS_LOCATION.resolve("interventions")).importArchitectureDecisionRecords(system)
     }
   }
 }

--- a/src/main/kotlin/model/Pathfinder.kt
+++ b/src/main/kotlin/model/Pathfinder.kt
@@ -1,4 +1,3 @@
-
 package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Container

--- a/src/main/kotlin/model/PrisonerContentHub.kt
+++ b/src/main/kotlin/model/PrisonerContentHub.kt
@@ -108,7 +108,7 @@ class PrisonerContentHub private constructor() {
     override fun defineRelationships() {
       contentHubFrontend.uses(NOMIS.prisonApi, "lookup visits, canteen, etc.")
       contentHubFrontend.uses(DigitalPrisonsNetwork.identity, "Prisoner logs in with OAuth2 flow")
-      
+
       frontendProxy.uses(NationalPrisonRadio.system, "proxy OGG livestream audio")
     }
 

--- a/src/main/kotlin/model/ProbationTeamsService.kt
+++ b/src/main/kotlin/model/ProbationTeamsService.kt
@@ -1,4 +1,3 @@
-
 package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.model.Container


### PR DESCRIPTION
## What does this pull request do?

Defines the initial proposed ADRs for interventions, which extend the initial architecture in #83.

### Notes

I am using the [structurizr-adr-tools][adr-tools] library to parse all ADRs in the `decisions/interventions` folder.

A new `DefinesDecisions` interface is an optional extension to `HMPPSSoftwareSystem`; both can be used on anything defined in `MODEL_ITEMS`.

The decisions will be published in Structurizr under its [decision log][log] page: https://structurizr.com/share/56937/decisions (which is currently empty until this is merged). It will look something like this:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/1526295/97972452-72ae1300-1dbc-11eb-9d42-c0e9342a67dc.png">

### What to review?

The ADR contents are

- [decisions/interventions/0001-split-ui-and-service.md](https://github.com/ministryofjustice/hmpps-architecture-as-code/blob/interventions-decisions/decisions/interventions/0001-split-ui-and-service.md)
- [decisions/interventions/0002-decouple-with-events.md](https://github.com/ministryofjustice/hmpps-architecture-as-code/blob/interventions-decisions/decisions/interventions/0002-decouple-with-events.md)

## What is the intent behind these changes?

To make sure the context and decisions annotating the #83 architecture are in the same place and are discoverable by everyone.

[adr-tools]: https://github.com/structurizr/java-extensions/tree/master/structurizr-adr-tools
[log]: https://structurizr.com/help/decision-log