### PR TITLE
Fetch API documentation URLs from application readmes

### DIFF
--- a/src/main/kotlin/annotations/APIDocs.kt
+++ b/src/main/kotlin/annotations/APIDocs.kt
@@ -2,10 +2,15 @@ package uk.gov.justice.hmpps.architecture.annotations
 
 import com.structurizr.model.Element
 
-class APIDocs(url: String) {
-  val url: String = url
-
+@Deprecated("Do not annotate Containers. Instead, please add an API docs badge to the GitHub repo's README")
+class APIDocs(private val url: String) {
   fun addTo(element: Element) {
     element.addProperty("api-docs-url", url)
+  }
+
+  companion object {
+    fun getFrom(element: Element): String? {
+      return element.properties["api-docs-url"]
+    }
   }
 }

--- a/src/main/kotlin/defineDocumentation.kt
+++ b/src/main/kotlin/defineDocumentation.kt
@@ -4,7 +4,10 @@ import com.structurizr.Workspace
 import com.structurizr.documentation.AutomaticDocumentationTemplate
 import com.structurizr.model.Container
 import com.structurizr.model.Model
+import org.eclipse.jgit.api.errors.GitAPIException
+import uk.gov.justice.hmpps.architecture.annotations.APIDocs
 import java.io.File
+import java.io.IOException
 import java.io.PrintWriter
 
 fun defineDocumentation(workspace: Workspace) {
@@ -23,15 +26,15 @@ private fun writeAPIs(w: PrintWriter, model: Model) {
   w.println("## Published APIs")
   w.println("")
 
-  val apis = model.softwareSystems
-    .sortedBy { it.name.toLowerCase() }
-    .flatMap { it.containers }
-    .filter { it.properties.get("api-docs-url") != null }
   w.println("| Software System | API name | Purpose | Links |")
   w.println("| --- | --- | --- | --- |")
-  apis.forEach { writeAPI(w, it) }
+
+  containersWithAPIDocs(model)
+    .also { println("[defineDocumentation] Found ${it.size} APIs with documentation URLs") }
+    .forEach { writeAPI(w, it) }
 }
 
+@Suppress("DEPRECATION")
 private fun writeAPI(w: PrintWriter, apiContainer: Container) {
   w.print("| ")
   w.print(apiContainer.softwareSystem.name)
@@ -44,9 +47,49 @@ private fun writeAPI(w: PrintWriter, apiContainer: Container) {
 
   w.print("| ")
   val githubLink = apiContainer.url
-  val apidocsLink = apiContainer.properties.get("api-docs-url")
+  val apidocsLink = APIDocs.getFrom(apiContainer)
   w.print(" [GitHub](%s)".format(githubLink))
   w.print(" [APIdocs](%s)".format(apidocsLink))
 
   w.println("|")
+}
+
+@Suppress("DEPRECATION")
+private fun containersWithAPIDocs(model: Model): List<Container> {
+  val containers = model.softwareSystems
+    .sortedBy { it.name.toLowerCase() }
+    .flatMap { it.containers }
+
+  containers
+    .filter { it.url.orEmpty().contains("github.com/ministryofjustice") }
+    .forEach {
+      val oldUrl = APIDocs.getFrom(it)
+      val url = readAPIDocsURLFromRepoReadmeBadge(it)
+
+      if (url != null) {
+        if (oldUrl != null) {
+          println("[defineDocumentation] overriding API docs URL\n - from ${oldUrl}\n - to   $url")
+        }
+        APIDocs(url).addTo(it)
+      }
+    }
+
+  return containers.filter { APIDocs.getFrom(it) != null }
+}
+
+val BADGE_URL_PATTERN = Regex("""\[!\[API docs]\(.*\)]\((.*)\)""")
+private fun readAPIDocsURLFromRepoReadmeBadge(app: Container): String? {
+  var readmeContents = ""
+  try {
+    println()
+    val repoDir = cloneRepository(app.url, app)
+    readmeContents = repoDir.resolve("README.md").readText()
+  } catch (e: GitAPIException) {
+    println("[defineDocumentation] ignoring: $e")
+  } catch (e: IOException) {
+    println("[defineDocumentation] ignoring: $e")
+  }
+
+  val m = BADGE_URL_PATTERN.find(readmeContents)
+  return m?.groups?.get(1)?.value
 }

--- a/src/main/kotlin/defineDocumentation.kt
+++ b/src/main/kotlin/defineDocumentation.kt
@@ -83,7 +83,8 @@ private fun readAPIDocsURLFromRepoReadmeBadge(app: Container): String? {
   try {
     println()
     val repoDir = cloneRepository(app.url, app)
-    readmeContents = repoDir.resolve("README.md").readText()
+    val readme = repoDir.listFiles { _, name -> name.equals("README.md", true) }?.first()
+    readmeContents = readme?.readText().orEmpty()
   } catch (e: GitAPIException) {
     println("[defineDocumentation] ignoring: $e")
   } catch (e: IOException) {

--- a/src/main/kotlin/git.kt
+++ b/src/main/kotlin/git.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.hmpps.architecture
+
+import com.structurizr.model.Element
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.MergeCommand
+import java.io.File
+
+fun cloneRepository(repoUrl: String, e: Element): File {
+  val cloneDir = App.EXPORT_LOCATION.resolve("clones").resolve(e.id)
+
+  println("[git] Processing $repoUrl")
+  if (cloneDir.resolve(".git").exists()) {
+    update(cloneDir)
+  } else {
+    clone(repoUrl, cloneDir)
+  }
+
+  return cloneDir
+}
+
+private fun clone(repoUrl: String, cloneDir: File) {
+  Git.cloneRepository()
+    .setURI(repoUrl)
+    .setDirectory(cloneDir)
+    .call()
+}
+
+private fun update(cloneDir: File) {
+  Git.open(cloneDir)
+    .pull()
+    .setFastForward(MergeCommand.FastForwardMode.FF_ONLY)
+    .call()
+}

--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -6,7 +6,6 @@ import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
-import uk.gov.justice.hmpps.architecture.annotations.APIDocs
 import uk.gov.justice.hmpps.architecture.annotations.ProblemArea
 import uk.gov.justice.hmpps.architecture.annotations.Tags
 
@@ -52,8 +51,7 @@ class Delius private constructor() {
         "Community API",
         "API over the nDelius DB used by HMPPS Digital team applications and services", "Java"
       ).apply {
-        APIDocs("https://community-api-public.test.delius.probation.hmpps.dsd.io/swagger-ui/index.html").addTo(this)
-        setUrl("https://github.com/ministryofjustice/community-api")
+        url = "https://github.com/ministryofjustice/community-api"
         uses(db, "connects to", "JDBC")
         ec2.add(this)
       }
@@ -71,8 +69,7 @@ class Delius private constructor() {
         "Generate events for the offender changes in probation",
         "Kotlin"
       ).apply {
-        APIDocs("https://probation-offender-events-dev.hmpps.service.justice.gov.uk/swagger-ui.html").addTo(this)
-        setUrl("https://github.com/ministryofjustice/probation-offender-events")
+        url = "https://github.com/ministryofjustice/probation-offender-events"
         uses(communityApi, "reads offender delta updates from")
         uses(topic, "notifies", "SNS")
         ec2.add(this)
@@ -83,8 +80,7 @@ class Delius private constructor() {
         "Service to update nDelius offender data held in Elasticsearch",
         "Kotlin"
       ).apply {
-        APIDocs("https://probation-search-indexer.hmpps.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config").addTo(this)
-        setUrl("https://github.com/ministryofjustice/probation-offender-search-indexer")
+        url = "https://github.com/ministryofjustice/probation-offender-search-indexer"
         uses(elasticSearchStore, "Indexes offender data from nDelius to the Elasticsearch Index")
         ec2.add(this)
       }
@@ -94,8 +90,7 @@ class Delius private constructor() {
         "API over the nDelius offender data held in Elasticsearch",
         "Kotlin"
       ).apply {
-        APIDocs("https://probation-offender-search.hmpps.service.justice.gov.uk/swagger-ui/index.html").addTo(this)
-        setUrl("https://github.com/ministryofjustice/probation-offender-search")
+        url = "https://github.com/ministryofjustice/probation-offender-search"
         uses(elasticSearchStore, "Queries offender data from nDelius Elasticsearch Index")
         uses(offenderSearchIndexer, "To synchronise date from nDelius to Elasticsearch")
         ec2.add(this)

--- a/src/main/kotlin/model/HMPPSAuth.kt
+++ b/src/main/kotlin/model/HMPPSAuth.kt
@@ -4,7 +4,6 @@ import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
-import uk.gov.justice.hmpps.architecture.annotations.APIDocs
 import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class HMPPSAuth private constructor() {
@@ -21,8 +20,7 @@ class HMPPSAuth private constructor() {
         "Spring Boot + Java"
       ).apply {
         Tags.WEB_BROWSER.addTo(this)
-        APIDocs("https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/swagger-ui.html").addTo(this)
-        setUrl("https://github.com/ministryofjustice/hmpps-auth")
+        url = "https://github.com/ministryofjustice/hmpps-auth"
       }
 
       val database = system.addContainer(

--- a/src/main/kotlin/model/NOMIS.kt
+++ b/src/main/kotlin/model/NOMIS.kt
@@ -41,8 +41,7 @@ class NOMIS private constructor() {
         "API over the NOMIS DB used by Digital Prison team applications and services", "Java"
       ).apply {
         addProperty("previous-name", "Elite2 API")
-        APIDocs("https://api.prison.service.justice.gov.uk/swagger-ui/index.html").addTo(this)
-        setUrl("https://github.com/ministryofjustice/prison-api")
+        url = "https://github.com/ministryofjustice/prison-api"
         uses(db, "connects to", "JDBC")
       }
 

--- a/src/main/kotlin/model/ProbationTeamsService.kt
+++ b/src/main/kotlin/model/ProbationTeamsService.kt
@@ -5,7 +5,6 @@ import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ViewSet
-import uk.gov.justice.hmpps.architecture.annotations.APIDocs
 import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class ProbationTeamsService private constructor() {
@@ -20,8 +19,7 @@ class ProbationTeamsService private constructor() {
       )
 
       api = system.addContainer("API", "API", "Kotlin + Spring Boot").apply {
-        APIDocs("https://probation-teams-dev.prison.service.justice.gov.uk/swagger-ui/index.html").addTo(this)
-        setUrl("https://github.com/ministryofjustice/probation-teams")
+        url = "https://github.com/ministryofjustice/probation-teams"
       }
 
       val db = system.addContainer("Database", "Storage for probation areas and Local Delivery Unit 'functional' mailboxes", "PostgreSQL").apply {

--- a/src/main/kotlin/pullADRs.kt
+++ b/src/main/kotlin/pullADRs.kt
@@ -5,16 +5,13 @@ import com.structurizr.documentation.AdrToolsImporter
 import uk.gov.justice.hmpps.architecture.annotations.ADRSource
 
 fun pullADRs(workspace: Workspace) {
-  val systemsWithADRs = workspace.model.softwareSystems.stream().filter { ADRSource.getFrom(it) != null }
+  workspace.model.softwareSystems.stream()
+    .filter { ADRSource.getFrom(it) != null }
+    .forEach {
+      val cloneDir = cloneRepository(ADRSource.getFrom(it)!!, it)
+      val decisions = AdrToolsImporter(workspace, cloneDir.resolve("doc/adr"))
+        .importArchitectureDecisionRecords(it)
 
-  systemsWithADRs.forEach {
-    println()
-    println("[pullADRs] For ${it.name}")
-
-    val cloneDir = cloneRepository(ADRSource.getFrom(it)!!, it)
-    val decisions = AdrToolsImporter(workspace, cloneDir.resolve("doc/adr"))
-      .importArchitectureDecisionRecords(it)
-
-    println("[pullADRs] Imported ${decisions.size} decisions")
-  }
+      println("[pullADRs] Imported ${decisions.size} decisions for '${it.name}'")
+    }
 }

--- a/src/main/kotlin/pullADRs.kt
+++ b/src/main/kotlin/pullADRs.kt
@@ -2,10 +2,7 @@ package uk.gov.justice.hmpps.architecture
 
 import com.structurizr.Workspace
 import com.structurizr.documentation.AdrToolsImporter
-import com.structurizr.model.SoftwareSystem
-import org.eclipse.jgit.api.Git
 import uk.gov.justice.hmpps.architecture.annotations.ADRSource
-import java.io.File
 
 fun pullADRs(workspace: Workspace) {
   val systemsWithADRs = workspace.model.softwareSystems.stream().filter { ADRSource.getFrom(it) != null }
@@ -14,26 +11,10 @@ fun pullADRs(workspace: Workspace) {
     println()
     println("[pullADRs] For ${it.name}")
 
-    val cloneDir = cloneADRRepo(it)
+    val cloneDir = cloneRepository(ADRSource.getFrom(it)!!, it)
     val decisions = AdrToolsImporter(workspace, cloneDir.resolve("doc/adr"))
       .importArchitectureDecisionRecords(it)
 
     println("[pullADRs] Imported ${decisions.size} decisions")
   }
-}
-
-private fun cloneADRRepo(system: SoftwareSystem): File {
-  val repo = ADRSource.getFrom(system)
-
-  val cloneDir = App.EXPORT_LOCATION.resolve("clones").resolve(system.id)
-  cloneDir.deleteRecursively()
-  cloneDir.mkdirs()
-
-  println("[pullADRs] Cloning ADR repo ($repo) to directory '$cloneDir'")
-  Git.cloneRepository()
-    .setURI(repo)
-    .setDirectory(cloneDir)
-    .call()
-
-  return cloneDir
 }


### PR DESCRIPTION
## What does this pull request do?

During the build, the app now fetches API documentation URLs from application readmes.

✨ New steps:

1. Clones the application repositories referenced in the model.
2. Greps the `README.md` file for an "API docs" badge.
3. If it exists, extracts the API docs URL.

Existing steps:

4. Creates an `exports/docs/apidocs.md` file with all the apps.
5. Publishes the result to [Structurizr](https://structurizr.com/share/56937/documentation#%2F:Published%20APIs) after merges.

**Requirements**

- Only works with publicly cloneable repos
- Picks up [![API docs](https://img.shields.io/badge/API_docs_-view-85EA2D.svg?logo=swagger)](https://example.org) badges:
    ```
    [![API docs](https://img.shields.io/badge/API_docs-view-85EA2D.svg?logo=swagger)](https://link.to/swagger)
    ```
- More specifically, has to match `\[!\[API docs\(.*\)]\((.*)\)`


## What is the intent behind these changes?

Automatically pick up API documentation from git repos: reduces the manual maintenance burden.