### PR TITLE
Update prison radio proxy tech to match reality

### DIFF
--- a/src/main/kotlin/model/PrisonerContentHub.kt
+++ b/src/main/kotlin/model/PrisonerContentHub.kt
@@ -67,7 +67,7 @@ class PrisonerContentHub private constructor() {
         CloudPlatform.kubernetes.add(this)
       }
 
-      frontendProxy = system.addContainer("Nginx ingress", "Proxy for media on external domains not accessible to prison users", "Nginx").apply {
+      frontendProxy = system.addContainer("ICEcast streamer", "Proxy for media on external domains not accessible to prison users", "ICEcast").apply {
         CloudPlatform.kubernetes.add(this)
       }
 


### PR DESCRIPTION
This updates the architecture diagram to show the ICEcast relay we now have running for prison radio in-cell.