### PR TITLE
Prisoner content hub s3 prisoner access

### DIFF
--- a/src/main/kotlin/model/PrisonerContentHub.kt
+++ b/src/main/kotlin/model/PrisonerContentHub.kt
@@ -87,6 +87,7 @@ class PrisonerContentHub private constructor() {
       model.addPerson("Prisoner / Young Offender", "A person held in the public prison estate or a Young Offender Institute").apply {
         uses(contentHubFrontend, "Views videos, audio programmes, site updates, and rehabilitative material")
         uses(frontendProxy, "Listens to National Prison Radio live stream")
+        uses(s3ContentStore, "Streams audio, video and uploaded media")
         OutsideHMPPS.addTo(this)
       }
 

--- a/src/main/kotlin/model/PrisonerContentHub.kt
+++ b/src/main/kotlin/model/PrisonerContentHub.kt
@@ -84,13 +84,7 @@ class PrisonerContentHub private constructor() {
         uses(kibanaDashboard, "Extracts CSV files of prisoner feedback, views individual feedback responses, and analyses sentiment and statistics of feedback")
       }
 
-      model.addPerson("Prisoner", "A prisoner over 18 years old, held in the public prison estate").apply {
-        uses(contentHubFrontend, "Views videos, audio programmes, site updates, and rehabilitative material")
-        uses(frontendProxy, "Listens to National Prison Radio live stream")
-        OutsideHMPPS.addTo(this)
-      }
-
-      model.addPerson("Young Offender", "A person under 18, held in a Young Offender Institute").apply {
+      model.addPerson("Prisoner / Young Offender", "A person held in the public prison estate or a Young Offender Institute").apply {
         uses(contentHubFrontend, "Views videos, audio programmes, site updates, and rehabilitative material")
         uses(frontendProxy, "Listens to National Prison Radio live stream")
         OutsideHMPPS.addTo(this)


### PR DESCRIPTION
## What does this pull request do?

This PR:

1. Merges the youth and adult person, because their roles are the same for the prisoner content hub. At the moment there's no difference to how we serve the two groups, so it doesn't feel worth having the extra complexity in our diagrams

2. Shows prisoner devices connect directly to S3. We applied this a while back but I didn't update it here 🤦. This change reduced load on the Drupal pods 🥳 .

![structurizr-56937-prisonerContentHubContainer](https://user-images.githubusercontent.com/464482/106871861-9e49dd80-66ca-11eb-8e79-253cea0b8e11.png)

