### PR TITLE
Add how the probation search indexer receives data

### DIFF
--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -82,6 +82,8 @@ class Delius private constructor() {
       ).apply {
         url = "https://github.com/ministryofjustice/probation-offender-search-indexer"
         uses(elasticSearchStore, "Indexes offender data from nDelius to the Elasticsearch Index")
+        uses(topic, "to know when to update a record, listens to offender changed events from", "SQS")
+        uses(communityApi, "following received events, retrieves latest offender records from")
         ec2.add(this)
       }
 


### PR DESCRIPTION
## What does this pull request do?

Document how the probation search indexer receives updates to the offender records.

Taken from its [readme](https://github.com/ministryofjustice/probation-offender-search-indexer).

## What is the intent behind these changes?

To be up-to-date.