### PR TITLE
Reflect plans around interventions->reporting pipe

### DIFF
--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.hmpps.architecture.annotations.Tags
 class Delius private constructor() {
   companion object : HMPPSSoftwareSystem {
     lateinit var system: SoftwareSystem
+    lateinit var database: Container
     lateinit var communityApi: Container
     lateinit var offenderSearch: Container
     lateinit var offenderSearchIndexer: Container
@@ -34,7 +35,7 @@ class Delius private constructor() {
         "(National Delius Support Team) Team supporting changes to data in National Delius"
       )
 
-      val db = system.addContainer("nDelius database", null, "Oracle").apply {
+      database = system.addContainer("nDelius database", null, "Oracle").apply {
         Tags.DATABASE.addTo(this)
         ec2.add(this)
       }
@@ -52,7 +53,7 @@ class Delius private constructor() {
         "API over the nDelius DB used by HMPPS Digital team applications and services", "Java"
       ).apply {
         url = "https://github.com/ministryofjustice/community-api"
-        uses(db, "connects to", "JDBC")
+        uses(database, "connects to", "JDBC")
         ec2.add(this)
       }
 


### PR DESCRIPTION
## What does this pull request do?

Reflect plans around interventions &rarr; reporting pipeline.

1. The ownership of the "transfer area" will sit with interventions. (Removes the landing bucket from `Reporting`)
2. A new SAP BODS component will scoop the data up. (Creates a new ETL container in `Reporting`)

Note: there is a potential that interventions can use the Analytical Platform landing bucket for this purpose. We still need to confirm that the proposed usage of the Analytical Platform is in line with the owners.

Additionally, clarified how NDMIS acquires data from nDelius.

## What is the intent behind these changes?

To reflect the current state.