### PR TITLE
Remove hardcoded API docs URL

### DIFF
--- a/src/main/kotlin/model/NOMIS.kt
+++ b/src/main/kotlin/model/NOMIS.kt
@@ -4,7 +4,6 @@ import com.structurizr.model.Container
 import com.structurizr.model.Model
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.ViewSet
-import uk.gov.justice.hmpps.architecture.annotations.APIDocs
 import uk.gov.justice.hmpps.architecture.annotations.Tags
 
 class NOMIS private constructor() {
@@ -66,7 +65,6 @@ class NOMIS private constructor() {
         "PrisonerSearch", "API over the NOMIS prisoner data held in Elasticsearch",
         "Kotlin"
       ).apply {
-        APIDocs("https://prisoner-offender-search.prison.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config").addTo(this)
         uses(elasticSearchStore, "Queries prisoner data from NOMIS Elasticsearch Index")
         setUrl("https://github.com/ministryofjustice/prisoner-offender-search")
         CloudPlatform.kubernetes.add(this)


### PR DESCRIPTION
## What does this pull request do?

Remove hardcoded API docs URL

The build said

```
[git] Processing https://github.com/ministryofjustice/prisoner-offender-search
[defineDocumentation] overriding API docs URL
 - from https://prisoner-offender-search.prison.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config
 - to   https://prisoner-offender-search-dev.prison.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config
```

which means it's defined in its README, so we no longer need to define it in the model 🎉 

## What is the intent behind these changes?

Remove hardcoding in favour of teams self-defining all their stuff.