### PR TITLE
Update CLI to latest version for better generated PlantUML diagrams

### DIFF
--- a/script/generate_images.sh
+++ b/script/generate_images.sh
@@ -2,15 +2,15 @@
 root_dir="$(git rev-parse --show-toplevel)"
 ext_dir="$root_dir/ext"
 exports_dir="$root_dir/exports"
-cli_version="1.2.0"
-cli_zip="$ext_dir/cli.zip"
+cli_version="1.10.1"
+cli_zip="$ext_dir/cli-${cli_version}.zip"
 
 mkdir -p "$ext_dir"
 if [ ! -f "$cli_zip" ]; then
   echo
   echo "🔧 Downloading Structurizr CLI..."
   wget "https://github.com/structurizr/cli/releases/download/v$cli_version/structurizr-cli-$cli_version.zip" -O"$cli_zip"
-  unzip -d"$ext_dir" "$cli_zip"
+  unzip -o -d"$ext_dir" "$cli_zip"
 fi
 
 echo

--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -27,7 +27,7 @@ class Delius private constructor() {
 
       system = model.addSoftwareSystem(
         "nDelius",
-        "National Delius\nSupporting the management of offenders and delivering national reporting and performance monitoring data"
+        "(National Delius) Supporting the management of offenders and delivering national reporting and performance monitoring data"
       ).apply {
         ProblemArea.GETTING_THE_RIGHT_REHABILITATION.addTo(this)
       }

--- a/src/main/kotlin/model/EPF.kt
+++ b/src/main/kotlin/model/EPF.kt
@@ -15,7 +15,7 @@ class EPF private constructor() {
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
         "EPF",
-        "Effective Proposal Framework\nPresents sentencing options to NPS staff in court who are providing sentencing advice to sentencers"
+        "(Effective Proposal Framework) Presents sentencing options to NPS staff in court who are providing sentencing advice to sentencers"
       ).apply {
         ProblemArea.GETTING_THE_RIGHT_REHABILITATION.addTo(this)
       }

--- a/src/main/kotlin/model/NID.kt
+++ b/src/main/kotlin/model/NID.kt
@@ -13,7 +13,7 @@ class NID private constructor() {
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
         "NID",
-        "(Deprecated) National Intervention Database\nSpreadsheet to store intervention details"
+        "(Deprecated) (National Intervention Database) Spreadsheet to store intervention details"
       ).apply {
         Tags.DEPRECATED.addTo(this)
         ProblemArea.GETTING_THE_RIGHT_REHABILITATION.addTo(this)

--- a/src/main/kotlin/model/NOMIS.kt
+++ b/src/main/kotlin/model/NOMIS.kt
@@ -18,7 +18,7 @@ class NOMIS private constructor() {
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
         "NOMIS",
-        "National Offender Management Information System,\nthe case management system for offender data in use in custody - both public and private prisons"
+        "(National Offender Management Information System) The case management system for offender data in use in custody - both public and private prisons"
       )
 
       db = system.addContainer("NOMIS database", null, "Oracle").apply {

--- a/src/main/kotlin/model/Pathfinder.kt
+++ b/src/main/kotlin/model/Pathfinder.kt
@@ -12,7 +12,7 @@ class Pathfinder(model: Model) {
   init {
     system = model.addSoftwareSystem(
       "Pathfinder",
-      "Pathfinder System,\nthe case management system for Pathfinder nominals"
+      "The case management system for Pathfinder nominals"
     )
 
     val db = system.addContainer(

--- a/src/main/kotlin/model/ProbationCaseSampler.kt
+++ b/src/main/kotlin/model/ProbationCaseSampler.kt
@@ -11,10 +11,8 @@ class ProbationCaseSampler private constructor() {
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
         "Probation Case Sampler",
-        """
-        API which produces a representative and evenly distributed list of probation cases
-        within a region and date range which form the basis of an on-site inspection
-        """.trimIndent()
+        "API which produces a representative and evenly distributed list of probation cases " +
+          "within a region and date range which form the basis of an on-site inspection"
       ).apply {
         setUrl("https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/1989181486/HMIP+Case+Sampling")
       }

--- a/src/main/kotlin/model/Reporting.kt
+++ b/src/main/kotlin/model/Reporting.kt
@@ -25,7 +25,7 @@ class Reporting private constructor() {
     override fun defineModelEntities(model: Model) {
       ndmis = model.addSoftwareSystem(
         "NDMIS",
-        "National Delius Management Information System,\nprovides reporting on nDelius data"
+        "(National Delius Management Information System) Provides reporting on nDelius data"
       ).apply {
         ProblemArea.GETTING_THE_RIGHT_REHABILITATION.addTo(this)
       }
@@ -50,7 +50,7 @@ class Reporting private constructor() {
       communityPerformanceTeam = model.addPerson("Community Performance team", "Reporting on HMPPS performance in the community")
       crcPerformanceAnalyst = model.addPerson("CRC performance analyst").apply { Tags.PROVIDER.addTo(this) }
       dataInnovationTeam = model.addPerson("Data Innovation, Analysis and Linking team", "Works on linked data from various non-HMPPS government departments")
-      nationalApplicationReportingTeam = model.addPerson("NART", "National Applications Reporting Team,\nResponsible for the delivery of reporting to stakeholders")
+      nationalApplicationReportingTeam = model.addPerson("NART", "(National Applications Reporting Team) Responsible for the delivery of reporting to stakeholders")
       npsPerformanceOfficer = model.addPerson("NPS performance and quality officer")
       prisonPerformanceTeam = model.addPerson("Prison Performance team", "Reporting on HMPPS performance in prison")
 


### PR DESCRIPTION
## What does this pull request do?

Update CLI to latest version for better generated PlantUML diagrams

The new version however does not support new lines in descriptions, please see b3aa202 for details

## What is the intent behind these changes?

For better diagrams:

| Before | After |
| --- | --- |
| ![structurizr-56937-interventions-container](https://user-images.githubusercontent.com/1526295/118319105-39382c00-b4f2-11eb-9232-a91b1a6414e5.png) | ![structurizr-56937-interventions-container](https://user-images.githubusercontent.com/1526295/118318853-dc3c7600-b4f1-11eb-9cab-2041e4b5273f.png)
|![structurizr-56937-interventions-deployment](https://user-images.githubusercontent.com/1526295/118319100-36d5d200-b4f2-11eb-9913-5b8694daf6f6.png) | ![structurizr-56937-interventions-deployment](https://user-images.githubusercontent.com/1526295/118318863-de9ed000-b4f1-11eb-957b-eb1bc0dacfec.png)