### PR TITLE
Update interventions↔reporting interactions

### DIFF
--- a/src/main/kotlin/annotations/Tags.kt
+++ b/src/main/kotlin/annotations/Tags.kt
@@ -6,6 +6,7 @@ enum class Tags : addTo {
   DATABASE,
   TOPIC,
   WEB_BROWSER,
+  REUSABLE_COMPONENT,
   PROVIDER {
     override fun addTo(element: Element) {
       super.addTo(element)

--- a/src/main/kotlin/defineStyles.kt
+++ b/src/main/kotlin/defineStyles.kt
@@ -12,6 +12,7 @@ fun defineStyles(styles: Styles) {
   styles.addElementStyle(Tags.DATABASE.toString()).shape(Shape.Cylinder)
   styles.addElementStyle(Tags.TOPIC.toString()).shape(Shape.Pipe)
   styles.addElementStyle(Tags.WEB_BROWSER.toString()).shape(Shape.WebBrowser)
+  styles.addElementStyle(Tags.REUSABLE_COMPONENT.toString()).shape(Shape.Hexagon)
   styles.addElementStyle(Tags.PLANNED.toString()).border(Border.Dotted).opacity(50)
 
   styles.addElementStyle(Tags.PROVIDER.toString()).background("#ccff99")

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -17,7 +17,6 @@ class Interventions private constructor() {
     lateinit var database: Container
     lateinit var translator: Container
     lateinit var collector: Container
-    lateinit var reportingBucket: Container
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
@@ -77,16 +76,6 @@ class Interventions private constructor() {
         CloudPlatform.kubernetes.add(this)
         Tags.PLANNED.addTo(this)
       }
-
-      reportingBucket = system.addContainer(
-        "Interventions reporting hand-off storage",
-        "Collects daily snapshots of domain events and intervention data for hand-off to NDMIS (reporting)",
-        "S3 bucket"
-      ).apply {
-        Tags.DATABASE.addTo(this)
-        Tags.PLANNED.addTo(this)
-        CloudPlatform.s3.add(this)
-      }
     }
 
     override fun defineRelationships() {
@@ -112,6 +101,7 @@ class Interventions private constructor() {
       collector.uses(HMPPSDomainEvents.topic, "subscribes to all intervention domain events from", "via SQS")
 
       translator.uses(Delius.communityApi, "maintains contacts, appointments, registrations with", "REST/HTTP")
+      collector.uses(Reporting.landingBucket, "pushes intervention data and custom reports daily to")
       collector.uses(AnalyticalPlatform.landingBucket, "pushes intervention data daily to")
     }
 

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -69,10 +69,11 @@ class Interventions private constructor() {
 
       collector = system.addContainer(
         "Intervention data collector",
-        "Collects daily snapshots of domain events and intervention data for hand-off to the Analytical Platform",
-        "undefined"
+        "Collects daily snapshots of intervention data for hand-off to S3 landing buckets for reporting or analytics",
+        "data-engineering-data-extractor"
       ).apply {
         uses(database, "reads snapshots of the intervention data from")
+        Tags.REUSABLE_COMPONENT.addTo(this)
         CloudPlatform.kubernetes.add(this)
         Tags.PLANNED.addTo(this)
       }

--- a/src/main/kotlin/model/Interventions.kt
+++ b/src/main/kotlin/model/Interventions.kt
@@ -98,7 +98,6 @@ class Interventions private constructor() {
 
       service.uses(HMPPSDomainEvents.topic, "publishes intervention domain events to", "SNS")
       translator.uses(HMPPSDomainEvents.topic, "subscribes to all intervention domain events from", "via SQS")
-      collector.uses(HMPPSDomainEvents.topic, "subscribes to all intervention domain events from", "via SQS")
 
       translator.uses(Delius.communityApi, "maintains contacts, appointments, registrations with", "REST/HTTP")
       collector.uses(Reporting.landingBucket, "pushes intervention data and custom reports daily to")


### PR DESCRIPTION
## What does this pull request do?

1. Clarifies ownership of the reporting landing bucket (it's on the NDMIS side)
2. Defines the "collector" as the `data-engineering-data-extractor`, showing it as a "reusable component". It's not a discrete system, but an image that every service can deploy independently

## What is the intent behind these changes?

Close the gap between the model and reality
