### PR TITLE
Dependency report

### DIFF
--- a/src/main/kotlin/defineDocumentation.kt
+++ b/src/main/kotlin/defineDocumentation.kt
@@ -44,6 +44,10 @@ private fun writeDependencies(w: PrintWriter, containersWithGit: List<Container>
   w.println("## Dependencies")
   w.println("")
 
+  w.println("- Latest [CircleCI orb](https://circleci.com/developer/orbs/orb/ministryofjustice/hmpps)")
+  w.println("- Latest [gradle-spring-boot](https://plugins.gradle.org/plugin/uk.gov.justice.hmpps.gradle-spring-boot)")
+  w.println("")
+
   w.println("| Software System | Application | CircleCI orb versions | gradle-spring-boot version |")
   w.println("| --- | --- | --- | --- |")
 

--- a/src/main/kotlin/defineDocumentation.kt
+++ b/src/main/kotlin/defineDocumentation.kt
@@ -3,8 +3,6 @@ package uk.gov.justice.hmpps.architecture
 import com.structurizr.Workspace
 import com.structurizr.documentation.AutomaticDocumentationTemplate
 import com.structurizr.model.Container
-import com.structurizr.model.Model
-import org.eclipse.jgit.api.errors.GitAPIException
 import uk.gov.justice.hmpps.architecture.annotations.APIDocs
 import java.io.File
 import java.io.IOException
@@ -14,24 +12,62 @@ fun defineDocumentation(workspace: Workspace) {
   val docsRoot = File(App.EXPORT_LOCATION, "docs/")
   docsRoot.mkdirs()
 
-  val w = File(docsRoot, "apidocs.md").printWriter()
-  writeAPIs(w, workspace.model)
-  w.close()
+  val containersWithGitRepos = containersWithGit(workspace.model)
+
+  File(docsRoot, "apidocs.md").printWriter().let {
+    writeAPIs(it, containersWithGitRepos)
+    it.close()
+  }
+
+  File(docsRoot, "dependencies.md").printWriter().let {
+    writeDependencies(it, containersWithGitRepos)
+    it.close()
+  }
 
   val template = AutomaticDocumentationTemplate(workspace)
   template.addSections(docsRoot)
 }
 
-private fun writeAPIs(w: PrintWriter, model: Model) {
+private fun writeAPIs(w: PrintWriter, containersWithGit: List<Container>) {
   w.println("## Published APIs")
   w.println("")
 
   w.println("| Software System | API name | Purpose | Links |")
   w.println("| --- | --- | --- | --- |")
 
-  containersWithAPIDocs(model)
+  containersWithAPIDocs(containersWithGit)
     .also { println("[defineDocumentation] Found ${it.size} APIs with documentation URLs") }
     .forEach { writeAPI(w, it) }
+}
+
+private fun writeDependencies(w: PrintWriter, containersWithGit: List<Container>) {
+  w.println("## Dependencies")
+  w.println("")
+
+  w.println("| Software System | Application | CircleCI orb versions | gradle-spring-boot version |")
+  w.println("| --- | --- | --- | --- |")
+
+  containersWithGit
+    .also { println("[defineDocumentation] Found ${it.size} applications with github repos") }
+    .forEach { writeDependency(w, it) }
+}
+
+fun writeDependency(w: PrintWriter, app: Container) {
+  val r = cloneRepository(app) ?: return
+
+  w.print("| ")
+  w.print(app.softwareSystem.name)
+
+  w.print("| ")
+  w.print("[${app.name}](${app.url})")
+
+  w.print("| ")
+  w.print(readCircleOrbVersion(r))
+
+  w.print("| ")
+  w.print(readGradlePluginVersion(r))
+
+  w.println("|")
 }
 
 @Suppress("DEPRECATION")
@@ -55,20 +91,14 @@ private fun writeAPI(w: PrintWriter, apiContainer: Container) {
 }
 
 @Suppress("DEPRECATION")
-private fun containersWithAPIDocs(model: Model): List<Container> {
-  return model.softwareSystems
-    .sortedBy { it.name.toLowerCase() }
-    .flatMap { it.containers }
+private fun containersWithAPIDocs(containersWithGit: List<Container>): List<Container> {
+  return containersWithGit
     .map { pullApiDocs(it) }
     .filter { APIDocs.getFrom(it) != null }
 }
 
 @Suppress("DEPRECATION")
 private fun pullApiDocs(container: Container): Container {
-  if (!container.url.orEmpty().contains("github.com/ministryofjustice")) {
-    return container
-  }
-
   val oldUrl = APIDocs.getFrom(container)
   val url = readAPIDocsURLFromRepoReadmeBadge(container)
 
@@ -86,11 +116,9 @@ private fun readAPIDocsURLFromRepoReadmeBadge(app: Container): String? {
   var readmeContents = ""
   try {
     println()
-    val repoDir = cloneRepository(app.url, app)
-    val readme = repoDir.listFiles { _, name -> name.equals("README.md", true) }?.first()
+    val repoDir = cloneRepository(app)
+    val readme = repoDir?.listFiles { _, name -> name.equals("README.md", true) }?.first()
     readmeContents = readme?.readText().orEmpty()
-  } catch (e: GitAPIException) {
-    println("[defineDocumentation] ignoring: $e")
   } catch (e: IOException) {
     println("[defineDocumentation] ignoring: $e")
   } catch (e: java.util.NoSuchElementException) {
@@ -99,4 +127,19 @@ private fun readAPIDocsURLFromRepoReadmeBadge(app: Container): String? {
 
   val m = BADGE_URL_PATTERN.find(readmeContents)
   return m?.groups?.get(1)?.value
+}
+
+private fun readCircleOrbVersion(repo: File): String {
+  val circleConfig = repo.resolve(".circleci").resolve("config.yml").takeIf { it.exists() }?.readText().orEmpty()
+
+  val circleOrb = Regex("ministryofjustice/(hmpps@[\\d.]*)").find(circleConfig)?.groups?.get(1)?.value
+  val dpsOrb = Regex("ministryofjustice/(dps@[\\d.]*)").find(circleConfig)?.groups?.get(1)?.value
+  return listOfNotNull(circleOrb, dpsOrb).joinToString("<br>")
+}
+
+private fun readGradlePluginVersion(repo: File): String {
+  val buildFile = repo.resolve("build.gradle.kts").takeIf { it.exists() }?.readText().orEmpty()
+
+  val m = Regex("""id\("uk.gov.justice.hmpps.gradle-spring-boot"\) version "([^"]*)"""").find(buildFile)
+  return m?.groups?.get(1)?.value.orEmpty()
 }

--- a/src/main/kotlin/defineDocumentation.kt
+++ b/src/main/kotlin/defineDocumentation.kt
@@ -137,9 +137,13 @@ private fun readCircleOrbVersion(repo: File): String {
   return listOfNotNull(circleOrb, dpsOrb).joinToString("<br>")
 }
 
+const val GRADLE_PATTERN = """id\("uk.gov.justice.hmpps.gradle-spring-boot"\) version "([^"]*)""""
 private fun readGradlePluginVersion(repo: File): String {
-  val buildFile = repo.resolve("build.gradle.kts").takeIf { it.exists() }?.readText().orEmpty()
+  val buildFileKt = repo.resolve("build.gradle.kts").takeIf { it.exists() }?.readText().orEmpty()
+  val buildFile = repo.resolve("build.gradle").takeIf { it.exists() }?.readText().orEmpty()
 
-  val m = Regex("""id\("uk.gov.justice.hmpps.gradle-spring-boot"\) version "([^"]*)"""").find(buildFile)
-  return m?.groups?.get(1)?.value.orEmpty()
+  return listOfNotNull(
+    Regex(GRADLE_PATTERN).find(buildFileKt)?.groups?.get(1)?.value,
+    Regex(GRADLE_PATTERN).find(buildFile)?.groups?.get(1)?.value,
+  ).joinToString("<br>")
 }

--- a/src/main/kotlin/git.kt
+++ b/src/main/kotlin/git.kt
@@ -1,18 +1,37 @@
 package uk.gov.justice.hmpps.architecture
 
+import com.structurizr.model.Container
 import com.structurizr.model.Element
+import com.structurizr.model.Model
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.MergeCommand
+import org.eclipse.jgit.api.errors.GitAPIException
 import java.io.File
 
-fun cloneRepository(repoUrl: String, e: Element): File {
+fun containersWithGit(model: Model): List<Container> {
+  return model.softwareSystems
+    .flatMap { it.containers }
+    .sortedBy { it.softwareSystem.name.lowercase() + it.name.lowercase() }
+    .filter { it.url.orEmpty().startsWith("https://github.com/ministryofjustice") }
+}
+
+fun cloneRepository(e: Element): File? {
+  return cloneRepository(e.url, e)
+}
+
+fun cloneRepository(repoUrl: String, e: Element): File? {
   val cloneDir = App.EXPORT_LOCATION.resolve("clones").resolve(e.id)
 
-  println("[git] Processing $repoUrl")
-  if (cloneDir.resolve(".git").exists()) {
-    update(cloneDir)
-  } else {
-    clone(repoUrl, cloneDir)
+  try {
+    if (cloneDir.resolve(".git").exists()) {
+      println("[git] $repoUrl already cloned -- doing nothing (force new clone with rm -rf exports/clones/)")
+    } else {
+      println("[git] Cloning $repoUrl")
+      clone(repoUrl, cloneDir)
+    }
+  } catch (e: GitAPIException) {
+    println("[git] ignoring: $e")
+    return null
   }
 
   return cloneDir

--- a/src/main/kotlin/model/Delius.kt
+++ b/src/main/kotlin/model/Delius.kt
@@ -63,7 +63,7 @@ class Delius private constructor() {
         "Delius API",
         "API over the nDelius DB used by HMPPS Digital team applications and services", "Kotlin"
       ).apply {
-        url = "https://github.com/ministryofjustice/delius-api"
+        url = "https://github.com/ministryofjustice/hmpps-delius-api"
         uses(database, "connects to", "JDBC")
         ecs.add(this)
       }

--- a/src/main/kotlin/pullADRs.kt
+++ b/src/main/kotlin/pullADRs.kt
@@ -9,7 +9,7 @@ fun pullADRs(workspace: Workspace) {
     .filter { ADRSource.getFrom(it) != null }
     .forEach {
       val cloneDir = cloneRepository(ADRSource.getFrom(it)!!, it)
-      val decisions = AdrToolsImporter(workspace, cloneDir.resolve("doc/adr"))
+      val decisions = AdrToolsImporter(workspace, cloneDir?.resolve("doc/adr"))
         .importArchitectureDecisionRecords(it)
 
       println("[pullADRs] Imported ${decisions.size} decisions for '${it.name}'")


### PR DESCRIPTION
## What does this pull request do?

1. Finds all containers with github/ministryofjustice `url`s
2. Clones them
3. Reads the circleci orb version from `.circleci/config.yml`
4. Reads the gradle-sprint-boot version from `build.gradle.kts`
5. Generates `exports/docs/dependencies.md`
6. Will publish it to https://structurizr.com/share/56937/documentation

I removed the `git pull` functionality as it was terribly slow. CI will pull fresh anyway

Generated file: https://gist.github.com/sldblog/bb171733565523e0469c62dca3772ddb:
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/1526295/121554285-ef1b6b00-ca09-11eb-9079-f7339cf45bbc.png">


## What is the intent behind these changes?

Make collecting and updating shared library data easier than spreadsheets :)