### PR TITLE
Updates to Prepare a Case for Sentence

### DIFF
--- a/src/main/kotlin/annotations/Tags.kt
+++ b/src/main/kotlin/annotations/Tags.kt
@@ -5,6 +5,7 @@ import com.structurizr.model.Element
 enum class Tags : addTo {
   DATABASE,
   TOPIC,
+  QUEUE,
   WEB_BROWSER,
   REUSABLE_COMPONENT,
   PROVIDER {

--- a/src/main/kotlin/defineStyles.kt
+++ b/src/main/kotlin/defineStyles.kt
@@ -11,6 +11,7 @@ fun defineStyles(styles: Styles) {
 
   styles.addElementStyle(Tags.DATABASE.toString()).shape(Shape.Cylinder)
   styles.addElementStyle(Tags.TOPIC.toString()).shape(Shape.Pipe)
+  styles.addElementStyle(Tags.QUEUE.toString()).shape(Shape.Pipe)
   styles.addElementStyle(Tags.WEB_BROWSER.toString()).shape(Shape.WebBrowser)
   styles.addElementStyle(Tags.REUSABLE_COMPONENT.toString()).shape(Shape.Hexagon)
   styles.addElementStyle(Tags.PLANNED.toString()).border(Border.Dotted).opacity(50)

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -36,7 +36,7 @@ private val MODEL_ITEMS = listOf(
   ManagePOMCases,
   PolicyTeams,
   PrisonerMoney,
-  PrepareCaseForCourt,
+  PrepareCaseForSentence,
   PrisonerContentHub,
   PrisonToProbationUpdate,
   PrisonVisitsBooking,

--- a/src/main/kotlin/model/AssessRisksAndNeeds.kt
+++ b/src/main/kotlin/model/AssessRisksAndNeeds.kt
@@ -54,7 +54,7 @@ class AssessRisksAndNeeds private constructor() {
         .forEach { it.uses(HMPPSAuth.system, "authenticates via") }
 
       assessmentService.uses(Delius.communityApi, "Gets offender and past-offence details from")
-      assessmentService.uses(PrepareCaseForCourt.courtCaseService, "Gets offender and offence details from")
+      assessmentService.uses(PrepareCaseForSentence.courtCaseService, "Gets offender and offence details from")
       assessmentService.uses(OASys.assessmentsApi, "get offender past assessment details from")
       assessmentService.uses(OASys.assessmentsUpdateApi, "pushes offender assessment details into")
 

--- a/src/main/kotlin/model/UserPreferenceApi.kt
+++ b/src/main/kotlin/model/UserPreferenceApi.kt
@@ -13,7 +13,7 @@ class UserPreferenceApi private constructor() {
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
-        "User preference api",
+        "User Preference API",
         "Stores preference information associated with a HMPPs Auth User"
       )
 


### PR DESCRIPTION
## What does this pull request do?

Models updates which have been made to the Prepare a Case for Sentence service
- Rename the service from **Prepare a Case for Court** to **Prepare a Case for Sentence**
- Prepare a Case for Sentence now uses **User Preferences** service
- The **Crime Portal Mirror Gateway** JBoss has been replaced by a Kotlin + Spring **Crime Portal Gateway**
- **Crime Portal Gateway** has supporting AWS S3 and SQS

## What is the intent behind these changes?
- Update the model
