### PR TITLE
Add dependabot for dependency version tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: "06:00"
+    timezone: Europe/London


### PR DESCRIPTION
## What does this pull request do?

Add dependabot for dependency version tracking

## What is the intent behind these changes?

Get notified and update out of date dependencies, once a week
