### PR TITLE
Add helm chart dependency tracking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/architecture/defineDocumentation.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/architecture/defineDocumentation.kt
@@ -48,10 +48,11 @@ private fun writeDependencies(w: PrintWriter, containersWithGit: List<Container>
 
   w.println("- Latest [CircleCI orb](https://circleci.com/developer/orbs/orb/ministryofjustice/hmpps)")
   w.println("- Latest [gradle-spring-boot](https://plugins.gradle.org/plugin/uk.gov.justice.hmpps.gradle-spring-boot)")
+  w.println("- Latest [helm charts](https://github.com/ministryofjustice/hmpps-helm-charts/releases)")
   w.println("")
 
-  w.println("| Software System | Application | CircleCI orb versions | gradle-spring-boot version |")
-  w.println("| --- | --- | --- | --- |")
+  w.println("| Software System | Application | CircleCI orb versions | gradle-spring-boot version | helm charts")
+  w.println("| --- | --- | --- | --- | --- |")
 
   parseVersions(containersWithGit)
     .forEach { writeDependency(w, it) }
@@ -69,6 +70,9 @@ fun writeDependency(w: PrintWriter, v: Version) {
 
   w.print("| ")
   w.print(v.gradleBootPluginVersion)
+
+  w.print("| ")
+  w.print(v.chartVersions)
 
   w.println("|")
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/architecture/defineDocumentation.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/architecture/defineDocumentation.kt
@@ -4,6 +4,8 @@ import com.structurizr.Workspace
 import com.structurizr.documentation.AutomaticDocumentationTemplate
 import com.structurizr.model.Container
 import uk.gov.justice.hmpps.architecture.annotations.APIDocs
+import uk.gov.justice.hmpps.architecture.documentation.Version
+import uk.gov.justice.hmpps.architecture.documentation.parseVersions
 import java.io.File
 import java.io.IOException
 import java.io.PrintWriter
@@ -51,25 +53,22 @@ private fun writeDependencies(w: PrintWriter, containersWithGit: List<Container>
   w.println("| Software System | Application | CircleCI orb versions | gradle-spring-boot version |")
   w.println("| --- | --- | --- | --- |")
 
-  containersWithGit
-    .also { println("[defineDocumentation] Found ${it.size} applications with github repos") }
+  parseVersions(containersWithGit)
     .forEach { writeDependency(w, it) }
 }
 
-fun writeDependency(w: PrintWriter, app: Container) {
-  val r = cloneRepository(app) ?: return
+fun writeDependency(w: PrintWriter, v: Version) {
+  w.print("| ")
+  w.print(v.softwareSystem)
 
   w.print("| ")
-  w.print(app.softwareSystem.name)
+  w.print("[${v.application}](${v.applicationUrl})")
 
   w.print("| ")
-  w.print("[${app.name}](${app.url})")
+  w.print(v.circleciOrbVersion)
 
   w.print("| ")
-  w.print(readCircleOrbVersion(r))
-
-  w.print("| ")
-  w.print(readGradlePluginVersion(r))
+  w.print(v.gradleBootPluginVersion)
 
   w.println("|")
 }
@@ -131,23 +130,4 @@ private fun readAPIDocsURLFromRepoReadmeBadge(app: Container): String? {
 
   val m = BADGE_URL_PATTERN.find(readmeContents)
   return m?.groups?.get(1)?.value
-}
-
-private fun readCircleOrbVersion(repo: File): String {
-  val circleConfig = repo.resolve(".circleci").resolve("config.yml").takeIf { it.exists() }?.readText().orEmpty()
-
-  val circleOrb = Regex("ministryofjustice/(hmpps@[\\d.]*)").find(circleConfig)?.groups?.get(1)?.value
-  val dpsOrb = Regex("ministryofjustice/(dps@[\\d.]*)").find(circleConfig)?.groups?.get(1)?.value
-  return listOfNotNull(circleOrb, dpsOrb).joinToString("<br>")
-}
-
-const val GRADLE_PATTERN = """id\("uk.gov.justice.hmpps.gradle-spring-boot"\) version "([^"]*)""""
-private fun readGradlePluginVersion(repo: File): String {
-  val buildFileKt = repo.resolve("build.gradle.kts").takeIf { it.exists() }?.readText().orEmpty()
-  val buildFile = repo.resolve("build.gradle").takeIf { it.exists() }?.readText().orEmpty()
-
-  return listOfNotNull(
-    Regex(GRADLE_PATTERN).find(buildFileKt)?.groups?.get(1)?.value,
-    Regex(GRADLE_PATTERN).find(buildFile)?.groups?.get(1)?.value,
-  ).joinToString("<br>")
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/architecture/documentation/versionTracker.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/architecture/documentation/versionTracker.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.hmpps.architecture.documentation
+
+import com.structurizr.model.Container
+import uk.gov.justice.hmpps.architecture.cloneRepository
+import java.io.File
+
+data class Version(
+  val softwareSystem: String,
+  val application: String,
+  val applicationUrl: String,
+  val circleciOrbVersion: String,
+  val gradleBootPluginVersion: String,
+)
+
+fun parseVersions(containersWithGit: List<Container>): List<Version> {
+  return containersWithGit
+    .also { println("[parseVersions] Found ${it.size} applications with github repos") }
+    .mapNotNull { parseVersion(it) }
+}
+
+private fun parseVersion(container: Container): Version? {
+  val r = cloneRepository(container) ?: return null
+  return Version(
+    softwareSystem = container.softwareSystem.name,
+    application = container.name,
+    applicationUrl = container.url,
+    circleciOrbVersion = readCircleOrbVersion(r),
+    gradleBootPluginVersion = readGradlePluginVersion(r)
+  )
+}
+
+private fun readCircleOrbVersion(repo: File): String {
+  val circleConfig = repo.resolve(".circleci").resolve("config.yml").takeIf { it.exists() }?.readText().orEmpty()
+
+  val circleOrb = Regex("ministryofjustice/(hmpps@[\\d.]*)").find(circleConfig)?.groups?.get(1)?.value
+  val dpsOrb = Regex("ministryofjustice/(dps@[\\d.]*)").find(circleConfig)?.groups?.get(1)?.value
+  return listOfNotNull(circleOrb, dpsOrb).joinToString("<br>")
+}
+
+const val GRADLE_PATTERN = """id\("uk.gov.justice.hmpps.gradle-spring-boot"\) version "([^"]*)""""
+private fun readGradlePluginVersion(repo: File): String {
+  val buildFileKt = repo.resolve("build.gradle.kts").takeIf { it.exists() }?.readText().orEmpty()
+  val buildFile = repo.resolve("build.gradle").takeIf { it.exists() }?.readText().orEmpty()
+
+  return listOfNotNull(
+    Regex(GRADLE_PATTERN).find(buildFileKt)?.groups?.get(1)?.value,
+    Regex(GRADLE_PATTERN).find(buildFile)?.groups?.get(1)?.value,
+  ).joinToString("<br>")
+}

--- a/src/main/kotlin/uk/gov/justice/hmpps/architecture/git.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/architecture/git.kt
@@ -20,7 +20,7 @@ fun cloneRepository(e: Element): File? {
 }
 
 fun cloneRepository(repoUrl: String, e: Element): File? {
-  val cloneDir = App.EXPORT_LOCATION.resolve("clones").resolve(e.id)
+  val cloneDir = App.EXPORT_LOCATION.resolve("clones").resolve(File(repoUrl).name)
 
   try {
     if (cloneDir.resolve(".git").exists()) {


### PR DESCRIPTION
## What does this pull request do?

Add helm chart dependency tracking to https://structurizr.com/share/56937/documentation/*#2

The main changes are in 2de6aa01cad5b69cd33d2e0918919d7c5368eee2

## What is the intent behind these changes?

To expose how up to date services are with the shared libraries/charts we provide