### PR TITLE
Render multiple items in dependencies with commas

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/architecture/defineDocumentation.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/architecture/defineDocumentation.kt
@@ -66,13 +66,13 @@ fun writeDependency(w: PrintWriter, v: Version) {
   w.print("[${v.application}](${v.applicationUrl})")
 
   w.print("| ")
-  w.print(v.circleciOrbVersion)
+  w.print(v.circleciOrbVersions.joinToString(", "))
 
   w.print("| ")
   w.print(v.gradleBootPluginVersion)
 
   w.print("| ")
-  w.print(v.chartVersions)
+  w.print(v.chartVersions.joinToString(", "))
 
   w.println("|")
 }


### PR DESCRIPTION


## What does this pull request do?

Render multiple items in dependencies with commas

And also don't do that during data gathering but only rendering

## What is the intent behind these changes?

To fix the rendering of multiple dependencies: the "newline" was stripped, so the current version is garbled together. This version separates the entries with `, `.

| Before | After |
| --- | --- |
|  <img width="605" alt="image" src="https://user-images.githubusercontent.com/1526295/144270533-4b9c48c6-1840-43dc-882d-702f33962ee5.png"> | <img width="563" alt="image" src="https://user-images.githubusercontent.com/1526295/144270810-140a8ebe-dc38-4ce9-a43a-3bfa3b7f363b.png"> |