### PR TITLE
🐛 Use the same Java version in publish as in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: '11'
       - run: |
           sudo apt-get -y install graphviz
           ./gradlew build


### PR DESCRIPTION

## What does this pull request do?

🐛 Use the same Java version in publish as in CI to fix the publishing failure:

<img width="526" alt="image" src="https://user-images.githubusercontent.com/1526295/145021965-fb817bf0-0f2e-41ca-9e5c-e232dcb546e5.png">


## What is the intent behind these changes?

This was missed in 95cd49ec3a5daaf955d8ab2c6e1ad78b5f73a734

Currently causing problems after #158:
`Error: Exception in thread "main" java.lang.UnsupportedClassVersionError: org/eclipse/jgit/api/errors/GitAPIException has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0`