### PR TITLE
Add API tags to risks and needs service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/architecture/model/AssessRisksAndNeeds.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/architecture/model/AssessRisksAndNeeds.kt
@@ -70,6 +70,8 @@ class AssessRisksAndNeeds private constructor() {
         "Risks and Needs business logic, Authoritative source for risk and needs data for offenders",
         "Kotlin + Spring Boot"
       ).apply {
+        Tags.DOMAIN_API.addTo(this)
+        Tags.AREA_PROBATION.addTo(this)
         uses(assessRiskNeedsDb, "connects to", "JDBC")
         setUrl("https://github.com/ministryofjustice/hmpps-assess-risks-and-needs")
         CloudPlatform.kubernetes.add(this)


### PR DESCRIPTION
## What does this pull request do?

Adds API and area tags 

## What is the intent behind these changes?

Include the risks and needs service in the API views
