### PR TITLE
Switch to Renovate so updates are grouped in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gradle
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: monday
-    time: "06:00"
-    timezone: Europe/London

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>ministryofjustice/hmpps-renovate-config:base"],
+  "packageRules": [
+    {
+      "matchManagers": ["gradle"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "all gradle dependencies",
+      "schedule": ["before 7am on Monday"],
+    },
+  ]
+}


### PR DESCRIPTION
## What does this pull request do?

Switch to Renovate, so updates are grouped in one PR

## What is the intent behind these changes?

Reduce maintenance PR volume.
