### PR TITLE
Pin Structurizr deps due to incompatible changes to the doc methods

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,7 +6,14 @@
       "matchManagers": ["gradle"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "all gradle dependencies",
-      "schedule": ["before 7am on Monday"],
+      "schedule": ["before 7am on Monday"]
     },
+    {
+      "matchPackageNames": [
+        "com.structurizr:structurizr-client",
+        "com.structurizr:structurizr-core"
+      ],
+      "allowedVersions": "1.21.0"
+    }
   ]
 }


### PR DESCRIPTION
## What does this pull request do?

Attempts to pin Structurizr dependencies as we are using the documentation methods in a way that isn't supported by recent changes

## What is the intent behind these changes?

Pin dependencies where upgrades require code changes and allow automatic updates to others 
